### PR TITLE
Don't split on space

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+xcuserdata

--- a/ControlRoom/Command.swift
+++ b/ControlRoom/Command.swift
@@ -42,8 +42,8 @@ enum Command {
     }
 
     /// Runs one simctl command and sends the result or error back on the main thread.
-    static func simctl(_ command: String, completion: ((Result<Data, CommandError>) -> Void)? = nil) {
-        let arguments = ["simctl"] + command.components(separatedBy: " ")
+    static func simctl(_ arguments: String..., completion: ((Result<Data, CommandError>) -> Void)? = nil) {
+        let arguments = ["simctl"] + arguments
         Command.run(command: "/usr/bin/xcrun", arguments: arguments, completion: completion)
     }
 }

--- a/ControlRoom/ControlScreens/AppView.swift
+++ b/ControlRoom/ControlScreens/AppView.swift
@@ -104,7 +104,7 @@ struct AppView: View {
 
     /// Reveals the app's container directory in Finder,
     func showContainer() {
-        Command.simctl("get_app_container \(self.simulator.udid) \(self.bundleID)") { result in
+        Command.simctl("get_app_container", self.simulator.udid, self.bundleID) { result in
             if let data = try? result.get() {
                 // We can't just "open" the app bundle URL, because
                 // macOS will attempt to execute the binary.
@@ -129,7 +129,7 @@ struct AppView: View {
 
         do {
             try self.pushPayload.write(to: fileURL, atomically: true, encoding: .utf8)
-            Command.simctl("push \(self.simulator.udid) \(self.bundleID) \(fileURL.path)")
+            Command.simctl("push", self.simulator.udid, self.bundleID, fileURL.path)
         } catch {
             print("Write error for URL: \(fileURL)")
         }
@@ -137,7 +137,7 @@ struct AppView: View {
 
     /// Removes the identified app from the device.
     func uninstallApp() {
-        Command.simctl("uninstall \(self.simulator.udid) \(self.bundleID)")
+        Command.simctl("uninstall", self.simulator.udid, self.bundleID)
     }
 
     /// Wrtes the user's URL to UserDefaults.
@@ -148,22 +148,22 @@ struct AppView: View {
     /// Opens a URL in the appropriate device app.
     func openURL() {
         saveAppURL()
-        Command.simctl("openurl \(self.simulator.udid) \(self.url)")
+        Command.simctl("openurl", self.simulator.udid, self.url)
     }
 
     /// Grants some type of permission to the app.
     func grantPrivacy() {
-        Command.simctl("privacy \(self.simulator.udid) grant \(self.resetPermission.lowercased()) \(self.bundleID)")
+        Command.simctl("privacy", self.simulator.udid, "grant", self.resetPermission.lowercased(), self.bundleID)
     }
 
     /// Revokes some type of permission from the app.
     func revokePrivacy() {
-        Command.simctl("privacy \(self.simulator.udid) revoke \(self.resetPermission.lowercased()) \(self.bundleID)")
+        Command.simctl("privacy", self.simulator.udid, "revoke", self.resetPermission.lowercased(), self.bundleID)
     }
 
     /// Resets some type of permission to the app, so it will be asked for again.
     func resetPrivacy() {
-        Command.simctl("privacy \(self.simulator.udid) reset \(self.resetPermission.lowercased()) \(self.bundleID)")
+        Command.simctl("privacy", self.simulator.udid, "reset", self.resetPermission.lowercased(), self.bundleID)
     }
 }
 

--- a/ControlRoom/ControlScreens/BatteryView.swift
+++ b/ControlRoom/ControlScreens/BatteryView.swift
@@ -42,10 +42,9 @@ struct BatteryView: View {
 
     /// Sends battery updates all at once; simctl gets unhappy if we send them individually.
     func updateBattery() {
-        var command = "status_bar \(self.simulator.udid) override "
-        command.append("--batteryLevel \(Int(self.batteryLevel)) ")
-        command.append("--batteryState \(batteryState.lowercased())")
-        Command.simctl(command)
+        Command.simctl("status_bar", self.simulator.udid, "override",
+                       "--batteryLevel", "\(Int(self.batteryLevel))",
+                       "--batteryState", batteryState.lowercased())
     }
 
     func levelChanged(_ editing: Bool) {

--- a/ControlRoom/ControlScreens/DataView.swift
+++ b/ControlRoom/ControlScreens/DataView.swift
@@ -116,14 +116,13 @@ struct DataView: View {
 
     /// Sends status bar updates all at once; simctl gets unhappy if we send them individually.
     func updateData() {
-        var command = "status_bar \(self.simulator.udid) override "
-        command.append("--dataNetwork \(dataNetwork.lowercased()) ")
-        command.append("--wifiMode \(wiFiMode.lowercased()) ")
-        command.append("--wifiBars \(wiFiBar) ")
-        command.append("--cellularMode \(cleanedCellularMode) ")
-        command.append("--cellularBars \(cellularBar) ")
-        command.append("--operatorName \(self.operatorName)")
-        Command.simctl(command)
+        Command.simctl("status_bar", self.simulator.udid, "override",
+                       "--dataNetwork", dataNetwork.lowercased(),
+                       "--wifiMode", wiFiMode.lowercased(),
+                       "--wifiBars", wiFiBar,
+                       "--cellularMode", cleanedCellularMode,
+                       "--cellularBars", cellularBar,
+                       "--operatorName", operatorName)
     }
 }
 

--- a/ControlRoom/ControlScreens/SystemView.swift
+++ b/ControlRoom/ControlScreens/SystemView.swift
@@ -82,37 +82,37 @@ struct SystemView: View {
 
     /// Changes the system clock to a new value.
     func setTime() {
-        Command.simctl("status_bar \(self.simulator.udid) override --time \(self.timeString)")
+        Command.simctl("status_bar", simulator.udid, "override", "--time", timeString)
     }
 
     /// Moves between light and dark mode.
     func updateAppearance() {
-        Command.simctl("ui \(simulator.udid) appearance \(appearance.lowercased())")
+        Command.simctl("ui", simulator.udid, "appearance", appearance.lowercased())
     }
 
     /// Starts an immediate iCloud sync.
     func triggerSync() {
-        Command.simctl("icloud_sync \(self.simulator.udid)")
+        Command.simctl("icloud_sync", simulator.udid)
     }
 
     /// Copies the simulator's pasteboard to the Mac.
     func copyPasteboardToMac() {
-        Command.simctl("pbsync \(self.simulator.udid) host")
+        Command.simctl("pbsync", simulator.udid, "host")
     }
 
     /// Copies the Mac's pasteboard to the simulator.
     func copyPasteboardToSim() {
-        Command.simctl("pbsync host \(self.simulator.udid)")
+        Command.simctl("pbsync", "host", simulator.udid)
     }
 
     /// Takes a screenshot of the device's current screen and saves it to the desktop.
     func takeScreenshot() {
-        Command.simctl("io \(self.simulator.udid) screenshot \(makeScreenshotFilename())")
+        Command.simctl("io", simulator.udid, "screenshot", makeScreenshotFilename())
     }
 
     /// Erases the current device.
     func eraseDevice() {
-        Command.simctl("erase \(self.simulator.udid)")
+        Command.simctl("erase", simulator.udid)
     }
 
     /// Creates a filename for a screenshot that ought to be unique

--- a/ControlRoom/ControlView.swift
+++ b/ControlRoom/ControlView.swift
@@ -46,12 +46,12 @@ struct ControlView: View {
 
     /// Launches the current device.
     func bootDevice() {
-        Command.simctl("boot \(self.currentSimulator.udid)")
+        Command.simctl("boot", currentSimulator.udid)
     }
 
     /// Terminates the current device.
     func shutdownDevice() {
-        Command.simctl("shutdown \(self.currentSimulator.udid)")
+        Command.simctl("shutdown", currentSimulator.udid)
     }
 }
 

--- a/ControlRoom/MainView.swift
+++ b/ControlRoom/MainView.swift
@@ -49,7 +49,7 @@ struct MainView: View {
 
     /// Calls simctl and reads the list of simulators the user has installed.
     private func fetchSimulators() {
-        Command.simctl("list devices available -j") { result in
+        Command.simctl("list", "devices", "available", "-j") { result in
             switch result {
             case .success(let data):
                 if let deviceOutput = try? JSONDecoder().decode(DeviceList.self, from: data) {


### PR DESCRIPTION
`Process` wants an array of strings to pass as parameters. While it definitely looks simpler to just pass in a single string and split it based on space, this can cause odd problems in weird cases (for example: spaces in paths).

This commit changes the simctl method to accept a variadic array of parameters, so that it doesn't have to do error-prone string splitting