### PR TITLE
Filter the list of simulators

### DIFF
--- a/ControlRoom.xcodeproj/project.pbxproj
+++ b/ControlRoom.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		51760B2D23F46073004532A9 /* Defaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51760B2C23F46073004532A9 /* Defaults.swift */; };
 		551F8CED23F489A50006D1BD /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551F8CEC23F489A50006D1BD /* SidebarView.swift */; };
 		551F8CEF23F48B030006D1BD /* SplitLayoutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551F8CEE23F48B030006D1BD /* SplitLayoutView.swift */; };
+		551F8CF123F498C30006D1BD /* SimulatorsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551F8CF023F498C30006D1BD /* SimulatorsController.swift */; };
+		551F8CF523F4AF7B0006D1BD /* FilterField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551F8CF423F4AF7B0006D1BD /* FilterField.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -53,6 +55,8 @@
 		51760B2C23F46073004532A9 /* Defaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Defaults.swift; sourceTree = "<group>"; };
 		551F8CEC23F489A50006D1BD /* SidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarView.swift; sourceTree = "<group>"; };
 		551F8CEE23F48B030006D1BD /* SplitLayoutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitLayoutView.swift; sourceTree = "<group>"; };
+		551F8CF023F498C30006D1BD /* SimulatorsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulatorsController.swift; sourceTree = "<group>"; };
+		551F8CF423F4AF7B0006D1BD /* FilterField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterField.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -95,6 +99,7 @@
 				551F8CEC23F489A50006D1BD /* SidebarView.swift */,
 				511BA59323F4079500E3E660 /* Command.swift */,
 				511BA59723F4096800E3E660 /* Simulator.swift */,
+				551F8CF023F498C30006D1BD /* SimulatorsController.swift */,
 			);
 			path = ControlRoom;
 			sourceTree = "<group>";
@@ -123,6 +128,7 @@
 			isa = PBXGroup;
 			children = (
 				511BA5A923F4316700E3E660 /* TextView.swift */,
+				551F8CF423F4AF7B0006D1BD /* FilterField.swift */,
 			);
 			path = NSViewWrappers;
 			sourceTree = "<group>";
@@ -242,11 +248,13 @@
 				511BA57D23F3FFEA00E3E660 /* AppDelegate.swift in Sources */,
 				511BA5A223F41A5900E3E660 /* Binding-OnChange.swift in Sources */,
 				511BA59823F4096800E3E660 /* Simulator.swift in Sources */,
+				551F8CF123F498C30006D1BD /* SimulatorsController.swift in Sources */,
 				511BA59423F4079500E3E660 /* Command.swift in Sources */,
 				511BA5A623F420AB00E3E660 /* FormSpacer.swift in Sources */,
 				51760B2D23F46073004532A9 /* Defaults.swift in Sources */,
 				511BA59023F4030D00E3E660 /* LoadingView.swift in Sources */,
 				511BA59623F408F800E3E660 /* LoadingFailedView.swift in Sources */,
+				551F8CF523F4AF7B0006D1BD /* FilterField.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ControlRoom/AppDelegate.swift
+++ b/ControlRoom/AppDelegate.swift
@@ -12,10 +12,11 @@ import SwiftUI
 @NSApplicationMain
 class AppDelegate: NSObject, NSApplicationDelegate {
     var window: NSWindow!
+    let controller = SimulatorsController()
 
     func applicationDidFinishLaunching(_ aNotification: Notification) {
         // Create the SwiftUI view that provides the window contents.
-        let contentView = MainView()
+        let contentView = MainView(controller: controller)
 
         // Create the window and set the content view. 
         window = NSWindow(

--- a/ControlRoom/MainView.swift
+++ b/ControlRoom/MainView.swift
@@ -10,63 +10,25 @@ import SwiftUI
 
 /// Hosts a LoadingView followed by the main ControlView, or a LoadingFailedView if simctl failed.
 struct MainView: View {
-    /// Handles decoding the device list from simctl
-    private struct DeviceList: Decodable {
-        var devices: [String: [Simulator]]
-    }
-
-    /// Tracks the state of fetching simulator data from simctl
-    private enum LoadingStatus {
-        /// Loading is in progress
-        case loading
-
-        /// Loading succeeded
-        case success
-
-        /// Loading failed
-        case failed
-    }
-
-    /// The current load state for the app.
-    @State private var loadingStatus = LoadingStatus.loading
-
-    /// An array of simulator data sent back from simctl.
-    @State private var simulators = [Simulator]()
+    
+    @ObservedObject var controller: SimulatorsController
 
     var body: some View {
         Group {
-            if loadingStatus == .loading {
+            if controller.loadingStatus == .loading {
                 LoadingView()
-            } else if loadingStatus == .success {
-                SplitLayoutView(simulators: simulators, selected: simulators.first)
+            } else if controller.loadingStatus == .success {
+                SplitLayoutView(controller: controller)
             } else {
                 LoadingFailedView()
             }
         }
         .frame(minWidth: 500, maxWidth: .infinity, minHeight: 500, maxHeight: .infinity)
-        .onAppear(perform: fetchSimulators)
-    }
-
-    /// Calls simctl and reads the list of simulators the user has installed.
-    private func fetchSimulators() {
-        Command.simctl("list", "devices", "available", "-j") { result in
-            switch result {
-            case .success(let data):
-                if let deviceOutput = try? JSONDecoder().decode(DeviceList.self, from: data) {
-                    self.simulators = [Simulator.default] + deviceOutput.devices.reduce([]) { $0 + $1.value }.sorted()
-                    self.loadingStatus = .success
-                } else {
-                    self.loadingStatus = .failed
-                }
-            case .failure:
-                self.loadingStatus = .failed
-            }
-        }
     }
 }
 
 struct MainView_Previews: PreviewProvider {
     static var previews: some View {
-        MainView()
+        MainView(controller: SimulatorsController())
     }
 }

--- a/ControlRoom/NSViewWrappers/FilterField.swift
+++ b/ControlRoom/NSViewWrappers/FilterField.swift
@@ -1,0 +1,50 @@
+//
+//  FilterField.swift
+//  ControlRoom
+//
+//  Created by Dave DeLong on 2/12/20.
+//  Copyright © 2020 Paul Hudson. All rights reserved.
+//
+
+import SwiftUI
+
+struct FilterField: NSViewRepresentable {
+    
+    let prompt: String
+    @Binding var text: String
+    
+    typealias NSViewType = NSTextField
+    
+    func makeCoordinator() -> FilterField.Coordinator {
+        return Coordinator(binding: $text)
+    }
+    
+    func makeNSView(context: NSViewRepresentableContext<FilterField>) -> NSTextField {
+        let tf = NSSearchField(string: text)
+        tf.placeholderString = prompt
+        tf.delegate = context.coordinator
+        tf.bezelStyle = .roundedBezel
+        tf.focusRingType = .none
+        return tf
+    }
+    
+    func updateNSView(_ nsView: NSTextField, context: NSViewRepresentableContext<FilterField>) {
+        nsView.stringValue = text
+    }
+    
+    class Coordinator: NSObject, NSSearchFieldDelegate {
+        
+        let binding: Binding<String>
+        init(binding: Binding<String>) {
+            self.binding = binding
+            super.init()
+        }
+        
+        func controlTextDidChange(_ obj: Notification) {
+            guard let field = obj.object as? NSTextField else { return }
+            binding.wrappedValue = field.stringValue
+        }
+        
+    }
+    
+}

--- a/ControlRoom/SidebarView.swift
+++ b/ControlRoom/SidebarView.swift
@@ -9,19 +9,23 @@
 import SwiftUI
 
 struct SidebarView: View {
-    var simulators: [Simulator]
-
-    let selectedSimulator: Binding<Simulator?>
+    @ObservedObject var controller: SimulatorsController
 
     var body: some View {
         GeometryReader { _ in
-            List(selection: self.selectedSimulator) {
-                ForEach(self.simulators) { simulator in
-                    Text(simulator.name)
-                        .tag(simulator)
+            VStack(spacing: 0) {
+                List(selection: self.$controller.selectedSimulator) {
+                    ForEach(self.controller.simulators) { simulator in
+                        Text(simulator.name)
+                            .tag(simulator)
+                    }
                 }
+                .listStyle(SidebarListStyle())
+                
+                Divider()
+                FilterField(prompt: "Filter", text: self.$controller.filterText)
+                .padding(2)
             }
-            .listStyle(SidebarListStyle())
         }
     }
 }
@@ -30,6 +34,6 @@ struct SidebarView_Previews: PreviewProvider {
     @State static var selected: Simulator?
 
     static var previews: some View {
-        SidebarView(simulators: [.example], selectedSimulator: $selected)
+        SidebarView(controller: SimulatorsController())
     }
 }

--- a/ControlRoom/SimulatorsController.swift
+++ b/ControlRoom/SimulatorsController.swift
@@ -1,0 +1,98 @@
+//
+//  SimulatorsController.swift
+//  ControlRoom
+//
+//  Created by Dave DeLong on 2/12/20.
+//  Copyright © 2020 Paul Hudson. All rights reserved.
+//
+
+import Combine
+import Foundation
+import SwiftUI
+
+/// Handles decoding the device list from simctl
+private struct DeviceList: Decodable {
+    var devices: [String: [Simulator]]
+}
+
+class SimulatorsController: ObservableObject {
+
+    /// Tracks the state of fetching simulator data from simctl
+    enum LoadingStatus {
+        /// Loading is in progress
+        case loading
+
+        /// Loading succeeded
+        case success
+
+        /// Loading failed
+        case failed
+    }
+    
+    private var allSimulators: [Simulator] = []
+    
+    @Published var loadingStatus: LoadingStatus = .loading
+    @Published var simulators: [Simulator] = []
+    
+    var filterText = "" {
+        willSet { objectWillChange.send() }
+        didSet { filterSimulators() }
+    }
+    
+    var selectedSimulator: Simulator? {
+        willSet { objectWillChange.send() }
+    }
+    
+    init() {
+        loadSimulators()
+    }
+    
+    private func loadSimulators() {
+        loadingStatus = .loading
+        
+        Command.simctl("list", "devices", "available", "-j") { result in
+            switch result {
+            case .success(let data):
+                let list = try? JSONDecoder().decode(DeviceList.self, from: data)
+                let parsed = list?.devices.values.flatMap { $0 }
+                self.handleParsedSimulators(parsed)
+            case .failure:
+                self.handleParsedSimulators(nil)
+            }
+        }
+    }
+    
+    private func handleParsedSimulators(_ newSimulators: [Simulator]?) {
+        objectWillChange.send()
+        
+        if let new = newSimulators {
+            allSimulators = [.default] + new
+            filterSimulators()
+            loadingStatus = .success
+        } else {
+            loadingStatus = .failed
+        }
+    }
+    
+    private func filterSimulators() {
+        let trimmed = filterText.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty == false {
+            simulators = allSimulators.filter { $0.name.localizedCaseInsensitiveContains(trimmed) }
+        } else {
+            simulators = allSimulators
+        }
+        
+        if let current = selectedSimulator {
+            if simulators.firstIndex(of: current) == nil {
+                // the current simulator is not in the list of filtered simulators
+                // deselect it
+                selectedSimulator = nil
+            }
+        }
+        
+        if selectedSimulator == nil {
+            selectedSimulator = simulators.first
+        }
+    }
+    
+}

--- a/ControlRoom/SplitLayoutView.swift
+++ b/ControlRoom/SplitLayoutView.swift
@@ -9,22 +9,21 @@
 import SwiftUI
 
 struct SplitLayoutView: View {
-    var simulators: [Simulator]
-    @State var selected: Simulator?
+    @ObservedObject var controller: SimulatorsController
 
     var body: some View {
         HSplitView {
-            SidebarView(simulators: simulators, selectedSimulator: $selected)
+            SidebarView(controller: controller)
                 .frame(minWidth: 200)
 
             // use a GeometryReader here to take up as much space as possible
             // otherwise the view would collapse down to (potentially)
             // the size of the Text
             GeometryReader { _ in
-                if self.selected == nil {
+                if self.controller.selectedSimulator == nil {
                     Text("Select a simulator from the list")
                 } else {
-                    ControlView(simulator: self.selected!)
+                    ControlView(simulator: self.controller.selectedSimulator!)
                         .padding()
                 }
             }
@@ -34,6 +33,6 @@ struct SplitLayoutView: View {
 
 struct SplitLayoutView_Previews: PreviewProvider {
     static var previews: some View {
-        SplitLayoutView(simulators: [.example], selected: nil)
+        SplitLayoutView(controller: SimulatorsController())
     }
 }


### PR DESCRIPTION
This adds a filter field at the bottom of the sidebar, like the filter field in Xcode's project navigator.

Part of this change also moves the logic for retrieving and filtering the list of simulators to a `SimulatorsController` class, which handles loading, parsing, and filtering the simulators. That object then gets passed around and observed by various views.

<img width="1209" alt="Screen Shot 2020-02-12 at 3 28 30 PM" src="https://user-images.githubusercontent.com/112699/74383530-a10e3d00-4dac-11ea-92dc-f06aff37b0fe.png">
