### PR TITLE
Use a default icon instead of force unwrapping

### DIFF
--- a/ControlRoom/Helpers/TypeIdentifier.swift
+++ b/ControlRoom/Helpers/TypeIdentifier.swift
@@ -37,7 +37,7 @@ struct TypeIdentifier: Hashable {
     }
 
     /// Iterates through this type identifier and all identifiers to which it conforms, looking for one that defines an icon
-    private var iconURL: URL? {
+    private var iconURL: URL {
         var typesToCheck = [self]
         var checked = Set<TypeIdentifier>()
 
@@ -62,11 +62,11 @@ struct TypeIdentifier: Hashable {
             typesToCheck.append(contentsOf: first.conformsTo)
         }
 
-        return nil
+        return URL(fileURLWithPath: "/System/Library/CoreServices/CoreTypes.bundle/Contents/Resources/GenericQuestionMarkIcon.icns")
     }
 
     /// Constructs an icon for this type identifier, as defined by its declaration
-    var icon: NSImage? { iconURL.map(NSImage.init(byReferencing:)) }
+    var icon: NSImage { NSImage.init(byReferencing: iconURL) }
 
     func hash(into hasher: inout Hasher) {
         hasher.combine(rawValue)

--- a/ControlRoom/Helpers/TypeIdentifier.swift
+++ b/ControlRoom/Helpers/TypeIdentifier.swift
@@ -37,7 +37,7 @@ struct TypeIdentifier: Hashable {
     }
 
     /// Iterates through this type identifier and all identifiers to which it conforms, looking for one that defines an icon
-    private var iconURL: URL {
+    private var iconURL: URL? {
         var typesToCheck = [self]
         var checked = Set<TypeIdentifier>()
 
@@ -62,11 +62,16 @@ struct TypeIdentifier: Hashable {
             typesToCheck.append(contentsOf: first.conformsTo)
         }
 
-        return URL(fileURLWithPath: "/System/Library/CoreServices/CoreTypes.bundle/Contents/Resources/GenericQuestionMarkIcon.icns")
+        return nil
     }
 
     /// Constructs an icon for this type identifier, as defined by its declaration
-    var icon: NSImage { NSImage.init(byReferencing: iconURL) }
+    var icon: NSImage {
+        if let iconURL = iconURL {
+            return NSImage(byReferencing: iconURL)
+        }
+        return NSWorkspace.shared.icon(forFileType: "'ques'")
+    }
 
     func hash(into hasher: inout Hasher) {
         hasher.combine(rawValue)

--- a/ControlRoom/Simulator.swift
+++ b/ControlRoom/Simulator.swift
@@ -30,7 +30,7 @@ struct Simulator: Identifiable, Comparable, Hashable {
         self.name = name
         self.udid = udid
         self.typeIdentifier = typeIdentifier
-        self.image = typeIdentifier.icon ?? TypeIdentifier.defaultiPhone.icon!
+        self.image = typeIdentifier.icon
     }
 
     /// Sort simulators alphabetically.


### PR DESCRIPTION
On my system `defaultiPhone` doesn't return a URL, which results in a crash when trying to set the image.  This change uses the built in `GenericQuestionMarkIcon.icns` as a default URL

<img width="223" alt="Screenshot 2020-02-13 10 23 30" src="https://user-images.githubusercontent.com/948806/74392834-b6867400-4e4b-11ea-8901-56bd3c024e76.png">
.