### PR TITLE
Provide default icons

### DIFF
--- a/ControlRoom/Helpers/TypeIdentifier.swift
+++ b/ControlRoom/Helpers/TypeIdentifier.swift
@@ -13,7 +13,10 @@ struct TypeIdentifier: Hashable {
     static let anyDevice = TypeIdentifier("public.device")
     static let phone = TypeIdentifier("com.apple.iphone")
     static let pad = TypeIdentifier("com.apple.ipad")
-    static let watch = TypeIdentifier("com.apple.watch")
+    // this uses com.apple.watch-42mm-1 instead of com.apple.watch
+    // com.apple.watch is declared in two places, and the default one doesn't declare an icon
+    // instead we'll use the OG 42mm watch, so can be sure to get an icon
+    static let watch = TypeIdentifier("com.apple.watch-42mm-1")
     static let tv = TypeIdentifier("com.apple.apple-tv")
 
     /// A default type identifier to be used for unknown simulators


### PR DESCRIPTION
Fixes #14

The issue is caused when the `simctl` output doesn't return a deviceTypeIdentifier. When that happened, we were defaulting to an "anyDevice" type identifier, which doesn't have an icon.

Instead, we'll capture fallback to using some basic name analysis to provide an approximate type identifier.