### PR TITLE
Use Combine for loading information

### DIFF
--- a/ControlRoom.xcodeproj/project.pbxproj
+++ b/ControlRoom.xcodeproj/project.pbxproj
@@ -31,6 +31,8 @@
 		551F8CF523F4AF7B0006D1BD /* FilterField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551F8CF423F4AF7B0006D1BD /* FilterField.swift */; };
 		551F8CF723F4BEAC0006D1BD /* TypeIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551F8CF623F4BEAC0006D1BD /* TypeIdentifier.swift */; };
 		551F8CF923F4C45A0006D1BD /* SimulatorSidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551F8CF823F4C45A0006D1BD /* SimulatorSidebarView.swift */; };
+		551F8CFE23F5C9EF0006D1BD /* SimCtl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551F8CFD23F5C9EF0006D1BD /* SimCtl.swift */; };
+		551F8D0023F5CB3A0006D1BD /* SimCtl+Types.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551F8CFF23F5CB3A0006D1BD /* SimCtl+Types.swift */; };
 		70BE435A23F54B7200FD6282 /* LocationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70BE435923F54B7200FD6282 /* LocationView.swift */; };
 		70BE435C23F54C8600FD6282 /* MapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70BE435B23F54C8600FD6282 /* MapView.swift */; };
 /* End PBXBuildFile section */
@@ -63,6 +65,8 @@
 		551F8CF423F4AF7B0006D1BD /* FilterField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterField.swift; sourceTree = "<group>"; };
 		551F8CF623F4BEAC0006D1BD /* TypeIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeIdentifier.swift; sourceTree = "<group>"; };
 		551F8CF823F4C45A0006D1BD /* SimulatorSidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulatorSidebarView.swift; sourceTree = "<group>"; };
+		551F8CFD23F5C9EF0006D1BD /* SimCtl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimCtl.swift; sourceTree = "<group>"; };
+		551F8CFF23F5CB3A0006D1BD /* SimCtl+Types.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SimCtl+Types.swift"; sourceTree = "<group>"; };
 		70BE435923F54B7200FD6282 /* LocationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationView.swift; sourceTree = "<group>"; };
 		70BE435B23F54C8600FD6282 /* MapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -107,6 +111,8 @@
 				551F8CEC23F489A50006D1BD /* SidebarView.swift */,
 				551F8CF823F4C45A0006D1BD /* SimulatorSidebarView.swift */,
 				511BA59323F4079500E3E660 /* Command.swift */,
+				551F8CFD23F5C9EF0006D1BD /* SimCtl.swift */,
+				551F8CFF23F5CB3A0006D1BD /* SimCtl+Types.swift */,
 				511BA59723F4096800E3E660 /* Simulator.swift */,
 				551F8CF023F498C30006D1BD /* SimulatorsController.swift */,
 			);
@@ -273,9 +279,11 @@
 				511BA5A823F42EE400E3E660 /* AppView.swift in Sources */,
 				551F8CED23F489A50006D1BD /* SidebarView.swift in Sources */,
 				551F8CEF23F48B030006D1BD /* SplitLayoutView.swift in Sources */,
+				551F8CFE23F5C9EF0006D1BD /* SimCtl.swift in Sources */,
 				511BA59223F4031F00E3E660 /* ControlView.swift in Sources */,
 				511BA57F23F3FFEA00E3E660 /* MainView.swift in Sources */,
 				511BA5AA23F4316700E3E660 /* TextView.swift in Sources */,
+				551F8D0023F5CB3A0006D1BD /* SimCtl+Types.swift in Sources */,
 				511BA5A023F4197200E3E660 /* DataView.swift in Sources */,
 				511BA59A23F415C800E3E660 /* BatteryView.swift in Sources */,
 				551F8CF923F4C45A0006D1BD /* SimulatorSidebarView.swift in Sources */,

--- a/ControlRoom/Command.swift
+++ b/ControlRoom/Command.swift
@@ -12,7 +12,9 @@ import Foundation
 enum Command {
     /// Errors we might get from running simctl
     enum CommandError: Error {
-        case missingCommand, missingOutput
+        case missingCommand
+        case missingOutput
+        case unknown(Error)
     }
 
     /// Runs one command using Process, and sends the result or error back on the main thread.

--- a/ControlRoom/ControlView.swift
+++ b/ControlRoom/ControlView.swift
@@ -19,8 +19,13 @@ struct ControlView: View {
                     .resizable()
                     .aspectRatio(1.0, contentMode: .fit)
                     .frame(maxWidth: 64)
-                Text(simulator.name)
-                    .font(.title)
+                VStack(alignment: .leading) {
+                    Text(simulator.name)
+                        .font(.title)
+                    if simulator.runtime != nil {
+                        Text(simulator.runtime!.description)
+                    }
+                }
                 Spacer()
                 Button("Boot", action: bootDevice)
                 Button("Shutdown", action: shutdownDevice)

--- a/ControlRoom/SimCtl+Types.swift
+++ b/ControlRoom/SimCtl+Types.swift
@@ -47,11 +47,45 @@ extension SimCtl {
     }
 
     struct Runtime: Decodable, Hashable {
-        static let unknown = Runtime(buildversion: "0A000", identifier: "Unknown", version: "0.0.0", isAvailable: false, name: "Unknown OS")
+        static let unknown = Runtime(buildversion: "", identifier: "Unknown", version: "0.0.0", isAvailable: false, name: "Default OS")
+        static let runtimeRegex = try? NSRegularExpression(pattern: #"^com\.apple\.CoreSimulator\.SimRuntime\.([a-z]+)-([0-9-]+)$"#, options: .caseInsensitive)
+
         let buildversion: String
         let identifier: String
         let version: String
         let isAvailable: Bool
         let name: String
+
+        /// The user-visible description of the runtime
+        var description: String {
+            if buildversion.isEmpty == false {
+                return "\(name) (\(buildversion))"
+            } else {
+                return "\(name)"
+            }
+        }
+
+        init(buildversion: String, identifier: String, version: String, isAvailable: Bool, name: String) {
+            self.buildversion = buildversion
+            self.identifier = identifier
+            self.version = version
+            self.isAvailable = isAvailable
+            self.name = name
+        }
+
+        init?(runtimeIdentifier: String) {
+            guard let match = Runtime.runtimeRegex?.firstMatch(in: runtimeIdentifier, options: [.anchored], range: NSRange(location: 0, length: runtimeIdentifier.utf16.count)) else {
+                return nil
+            }
+            let nsIdentifier = runtimeIdentifier as NSString
+            let os = nsIdentifier.substring(with: match.range(at: 1))
+            let version = nsIdentifier.substring(with: match.range(at: 2)).replacingOccurrences(of: "_", with: ".")
+
+            self.buildversion = ""
+            self.identifier = runtimeIdentifier
+            self.version = version
+            self.name = "\(os) \(version)"
+            self.isAvailable = false
+        }
     }
 }

--- a/ControlRoom/SimCtl+Types.swift
+++ b/ControlRoom/SimCtl+Types.swift
@@ -46,8 +46,9 @@ extension SimCtl {
         let runtimes: [Runtime]
     }
 
-    struct Runtime: Decodable {
-        let buildVersion: String
+    struct Runtime: Decodable, Hashable {
+        static let unknown = Runtime(buildversion: "0A000", identifier: "Unknown", version: "0.0.0", isAvailable: false, name: "Unknown OS")
+        let buildversion: String
         let identifier: String
         let version: String
         let isAvailable: Bool

--- a/ControlRoom/SimCtl+Types.swift
+++ b/ControlRoom/SimCtl+Types.swift
@@ -1,0 +1,56 @@
+//
+//  SimCtl+Types.swift
+//  ControlRoom
+//
+//  Created by Dave DeLong on 2/13/20.
+//  Copyright © 2020 Paul Hudson. All rights reserved.
+//
+
+import Foundation
+
+extension SimCtl {
+
+    struct DeviceTypeList: Decodable {
+        let devicetypes: [DeviceType]
+    }
+
+    struct DeviceType: Decodable {
+        let bundlePath: String
+        let name: String
+        let identifier: String
+
+        var modelTypeIdentifier: TypeIdentifier? {
+            guard let bundle = Bundle(path: bundlePath) else { return nil }
+            guard let plist = bundle.url(forResource: "profile", withExtension: "plist") else { return nil }
+            guard let contents = NSDictionary(contentsOf: plist) else { return nil }
+            guard let modelIdentifier = contents.object(forKey: "modelIdentifier") as? String else { return nil }
+
+            return TypeIdentifier(modelIdentifier: modelIdentifier)
+        }
+    }
+
+    struct DeviceList: Decodable {
+        let devices: [String: [Device]]
+    }
+
+    struct Device: Decodable {
+        let status: String?
+        let isAvailable: Bool
+        let name: String
+        let udid: String
+        let deviceTypeIdentifier: String?
+        let dataPath: String?
+    }
+
+    struct RuntimeList: Decodable {
+        let runtimes: [Runtime]
+    }
+
+    struct Runtime: Decodable {
+        let buildVersion: String
+        let identifier: String
+        let version: String
+        let isAvailable: Bool
+        let name: String
+    }
+}

--- a/ControlRoom/SimCtl.swift
+++ b/ControlRoom/SimCtl.swift
@@ -1,0 +1,59 @@
+//
+//  SimCtl.swift
+//  ControlRoom
+//
+//  Created by Dave DeLong on 2/13/20.
+//  Copyright © 2020 Paul Hudson. All rights reserved.
+//
+
+import Foundation
+import Combine
+
+enum SimCtl {
+    private static func execute(_ arguments: [String]) -> PassthroughSubject<Data, Command.CommandError> {
+        let publisher = PassthroughSubject<Data, Command.CommandError>()
+        DispatchQueue.global(qos: .userInitiated).async {
+            let task = Process()
+            task.launchPath = "/usr/bin/xcrun"
+            task.arguments = ["simctl"] + arguments
+            print(arguments)
+
+            let pipe = Pipe()
+            task.standardOutput = pipe
+
+            do {
+                try task.run()
+                let data = pipe.fileHandleForReading.readDataToEndOfFile()
+                publisher.send(data)
+                publisher.send(completion: .finished)
+            } catch {
+                publisher.send(completion: .failure(.missingCommand))
+            }
+        }
+        return publisher
+    }
+
+    private static func executeJSON<T: Decodable>(_ arguments: [String]) -> AnyPublisher<T, Command.CommandError> {
+        return execute(arguments).decode(type: T.self, decoder: JSONDecoder()).mapError({ error -> Command.CommandError in
+            if error is DecodingError {
+                return .missingOutput
+            } else if let command = error as? Command.CommandError {
+                return command
+            } else {
+                return .unknown(error)
+            }
+        }).eraseToAnyPublisher()
+    }
+
+    static func listDeviceTypes() -> AnyPublisher<DeviceTypeList, Command.CommandError> {
+        return executeJSON(["list", "devicetypes", "-j"])
+    }
+
+    static func listDevices() -> AnyPublisher<DeviceList, Command.CommandError> {
+        return executeJSON(["list", "devices", "available", "-j"])
+    }
+
+    static func listRuntimes() -> AnyPublisher<RuntimeList, Command.CommandError> {
+        return executeJSON(["list", "runtimes", "-j"])
+    }
+}

--- a/ControlRoom/Simulator.swift
+++ b/ControlRoom/Simulator.swift
@@ -45,9 +45,9 @@ struct Simulator: Identifiable, Comparable, Hashable {
     let platform: Platform
 
     /// The information about the simulator OS
-    let runtime: SimCtl.Runtime
+    let runtime: SimCtl.Runtime?
 
-    init(name: String, udid: String, typeIdentifier: TypeIdentifier, runtime: SimCtl.Runtime) {
+    init(name: String, udid: String, typeIdentifier: TypeIdentifier, runtime: SimCtl.Runtime?) {
         self.name = name
         self.udid = udid
         self.typeIdentifier = typeIdentifier
@@ -75,5 +75,5 @@ struct Simulator: Identifiable, Comparable, Hashable {
 
     /// Users whichever simulator simctl feels like; if there's only one active it will be used,
     /// but if there's more than one simctl just picks one.
-    static let `default` = Simulator(name: "Default", udid: "booted", typeIdentifier: .defaultiPhone, runtime: .unknown)
+    static let `default` = Simulator(name: "Default", udid: "booted", typeIdentifier: .defaultiPhone, runtime: nil)
 }

--- a/ControlRoom/Simulator.swift
+++ b/ControlRoom/Simulator.swift
@@ -44,11 +44,15 @@ struct Simulator: Identifiable, Comparable, Hashable {
     /// The platform of the simulator
     let platform: Platform
 
-    init(name: String, udid: String, typeIdentifier: TypeIdentifier) {
+    /// The information about the simulator OS
+    let runtime: SimCtl.Runtime
+
+    init(name: String, udid: String, typeIdentifier: TypeIdentifier, runtime: SimCtl.Runtime) {
         self.name = name
         self.udid = udid
         self.typeIdentifier = typeIdentifier
         self.image = typeIdentifier.icon
+        self.runtime = runtime
 
         if typeIdentifier.conformsTo(.pad) {
             self.platform = .iPad
@@ -67,9 +71,9 @@ struct Simulator: Identifiable, Comparable, Hashable {
     }
 
     /// An example simulator for Xcode preview purposes
-    static let example = Simulator(name: "iPhone 11 Pro max", udid: UUID().uuidString, typeIdentifier: .defaultiPhone)
+    static let example = Simulator(name: "iPhone 11 Pro max", udid: UUID().uuidString, typeIdentifier: .defaultiPhone, runtime: .unknown)
 
     /// Users whichever simulator simctl feels like; if there's only one active it will be used,
     /// but if there's more than one simctl just picks one.
-    static let `default` = Simulator(name: "Default", udid: "booted", typeIdentifier: .defaultiPhone)
+    static let `default` = Simulator(name: "Default", udid: "booted", typeIdentifier: .defaultiPhone, runtime: .unknown)
 }

--- a/ControlRoom/SimulatorsController.swift
+++ b/ControlRoom/SimulatorsController.swift
@@ -10,48 +10,6 @@ import Combine
 import Foundation
 import SwiftUI
 
-extension SimCtl.DeviceList {
-    fileprivate var simulators: [SimCtl.Simulator] {
-        devices.flatMap { element -> [SimCtl.Simulator] in
-            let (key, sims) = element
-            return sims.map { SimCtl.Simulator(decoded: $0, runtimeIdentifier: key) }
-        }
-    }
-}
-
-extension SimCtl {
-    fileprivate struct Simulator {
-        let status: String?
-        let isAvailable: Bool
-        let name: String
-        let udid: String
-        let runtimeIdentifier: String
-        let deviceTypeIdentifier: String?
-        let dataPath: String?
-
-        init(decoded: Device, runtimeIdentifier: String) {
-            self.status = decoded.status
-            self.isAvailable = decoded.isAvailable
-            self.name = decoded.name
-            self.udid = decoded.udid
-            self.runtimeIdentifier = runtimeIdentifier
-            self.dataPath = decoded.dataPath
-            self.deviceTypeIdentifier = decoded.deviceTypeIdentifier
-        }
-
-        func inferModelTypeIdentifier(using deviceTypes: [String: DeviceType]) -> TypeIdentifier {
-            if let typeID = deviceTypeIdentifier, let device = deviceTypes[typeID], let model = device.modelTypeIdentifier {
-                return model
-            }
-            // fall back to inferring the model type from the name
-            if name.contains("iPad") { return .defaultiPad }
-            if name.contains("Watch") { return .defaultWatch }
-            if name.contains("TV") { return .defaultTV }
-            return .defaultiPhone
-        }
-    }
-}
-
 /// A centralized class that loads simulator data and handles filtering.
 class SimulatorsController: ObservableObject {
 
@@ -101,25 +59,11 @@ class SimulatorsController: ObservableObject {
         let deviceTypes = SimCtl.listDeviceTypes()
         let runtimes = SimCtl.listRuntimes()
 
-        let combined = devices.combineLatest(deviceTypes, runtimes)
-        combined.sink(receiveCompletion: self.finishedLoadingSimulators,
-                      receiveValue: self.handleLoadedInformation)
+        devices.combineLatest(deviceTypes, runtimes)
+            .receive(on: DispatchQueue.main)
+            .sink(receiveCompletion: self.finishedLoadingSimulators,
+                  receiveValue: self.handleLoadedInformation)
             .store(in: &cancellables)
-
-        Command.simctl("list", "devices", "available", "-j") { result in
-            switch result {
-            case .success(let data):
-                do {
-                    let list = try JSONDecoder().decode(SimCtl.DeviceList.self, from: data)
-                    let parsed = list.simulators
-                    self.loadDeviceTypes(parsedSimulators: parsed)
-                } catch {
-                    print(error)
-                }
-            case .failure:
-                self.loadDeviceTypes(parsedSimulators: nil)
-            }
-        }
     }
 
     private func handleLoadedInformation(_ deviceList: SimCtl.DeviceList, _ deviceTypes: SimCtl.DeviceTypeList, _ runtimes: SimCtl.RuntimeList) {
@@ -127,65 +71,44 @@ class SimulatorsController: ObservableObject {
 
         let lookupDeviceType = Dictionary(grouping: deviceTypes.devicetypes, by: { $0.identifier }).compactMapValues({ $0.first })
         let lookupRuntime = Dictionary(grouping: runtimes.runtimes, by: { $0.identifier }).compactMapValues({ $0.first })
-        for (deviceType, devices) in deviceList.devices {
+        for (runtimeIdentifier, devices) in deviceList.devices {
+            let runtime: SimCtl.Runtime
+            if let known = lookupRuntime[runtimeIdentifier] {
+                runtime = known
+            } else {
+                runtime = .unknown
+            }
+
             for device in devices {
                 let model: TypeIdentifier
                 if let deviceType = lookupDeviceType[device.deviceTypeIdentifier ?? ""], let modelType = deviceType.modelTypeIdentifier {
                     model = modelType
                 } else if device.name.contains("iPad") {
-                    model = .pad
+                    model = .defaultiPad
                 } else if device.name.contains("Watch") {
-                    model = .watch
+                    model = .defaultWatch
                 } else if device.name.contains("TV") {
-                    model = .tv
+                    model = .defaultTV
                 } else {
                     model = .defaultiPhone
                 }
+
+                let sim = Simulator(name: device.name, udid: device.udid, typeIdentifier: model, runtime: runtime)
+                final.append(sim)
             }
         }
 
-        self.simulators = final
+        objectWillChange.send()
+        allSimulators = [.default] + final.sorted()
+        filterSimulators()
     }
 
     private func finishedLoadingSimulators(_ completion: Subscribers.Completion<Command.CommandError>) {
-
-    }
-
-    /// Fetches the kinds of simulators supports by simctl
-    private func loadDeviceTypes(parsedSimulators: [SimCtl.Simulator]?) {
-        Command.simctl("list", "devicetypes", "-j") { result in
-            switch result {
-            case .success(let data):
-                let list = try? JSONDecoder().decode(SimCtl.DeviceTypeList.self, from: data)
-                self.merge(parsedSimulators: parsedSimulators, deviceTypes: list?.devicetypes)
-            case .failure:
-                self.merge(parsedSimulators: parsedSimulators, deviceTypes: nil)
-            }
-        }
-    }
-
-    /// Merges the known simulators with the simulator definitions
-    private func merge(parsedSimulators: [SimCtl.Simulator]?, deviceTypes: [SimCtl.DeviceType]?) {
-        let rawTypes = deviceTypes ?? []
-        let typesByIdentifier = Dictionary(grouping: rawTypes, by: { $0.identifier }).compactMapValues({ $0.first })
-
-        let merged = parsedSimulators?.map { sim -> Simulator in
-            let modelType = sim.inferModelTypeIdentifier(using: typesByIdentifier)
-            return Simulator(name: sim.name, udid: sim.udid, typeIdentifier: modelType)
-        }
-
-        handleParsedSimulators(merged)
-    }
-
-    /// Filters the loaded simulators and updates our UI.
-    private func handleParsedSimulators(_ newSimulators: [Simulator]?) {
         objectWillChange.send()
-
-        if let new = newSimulators {
-            allSimulators = [.default] + new.sorted()
-            filterSimulators()
+        switch completion {
+        case .finished:
             loadingStatus = .success
-        } else {
+        case .failure:
             loadingStatus = .failed
         }
     }


### PR DESCRIPTION
The code in `SimulatorsController` to load up the various pieces of information was quickly getting hairy with lots of sequential callbacks.

The big change in this PR is to provide a Combine wrapper around certain SimCtl commands (with the eventual goal of moving the others to use it as well). This makes the `SimulatorsController` logic _much_ simpler.

This also adds loading up Runtime information via `simctl list runtimes -j` and using that to supplement the existing runtime information parsed from the runtime identifier.

The OS version is now shown as a sub-text on the ControlView, as opposed to being part of the name. (Fixes #8)
<img width="812" alt="Screen Shot 2020-02-13 at 12 59 08 PM" src="https://user-images.githubusercontent.com/112699/74473542-03287a00-4e61-11ea-8b06-2a65fb238eef.png">
