### PR TITLE
Device state

### DIFF
--- a/ControlRoom/ControlView.swift
+++ b/ControlRoom/ControlView.swift
@@ -27,8 +27,14 @@ struct ControlView: View {
                     }
                 }
                 Spacer()
-                Button("Boot", action: bootDevice)
-                Button("Shutdown", action: shutdownDevice)
+                VStack {
+                    if simulator.state != .booted {
+                        Button("Boot", action: bootDevice)
+                    }
+                    if simulator.state != .shutdown {
+                        Button("Shutdown", action: shutdownDevice)
+                    }
+                }
             }
             .padding(.bottom, 10)
 
@@ -38,7 +44,7 @@ struct ControlView: View {
                 BatteryView(simulator: simulator)
                 DataView(simulator: simulator)
                 LocationView(simulator: simulator)
-            }
+            }.disabled(simulator.state != .booted)
         }
         .padding()
     }

--- a/ControlRoom/SidebarView.swift
+++ b/ControlRoom/SidebarView.swift
@@ -16,12 +16,12 @@ struct SidebarView: View {
 
         return GeometryReader { _ in
             VStack(spacing: 0) {
-                List(selection: self.$controller.selectedSimulator) {
+                List(selection: self.$controller.selectedSimulatorID) {
                     ForEach(Simulator.Platform.allCases, id: \.self) { platform in
                         Section(header: Text(platform.displayName.uppercased())) {
                             ForEach(groups[platform] ?? []) { simulator in
                                 SimulatorSidebarView(simulator: simulator)
-                                    .tag(simulator)
+                                    .tag(simulator.udid)
                             }
                         }
                     }

--- a/ControlRoom/SimCtl+Types.swift
+++ b/ControlRoom/SimCtl+Types.swift
@@ -14,7 +14,7 @@ extension SimCtl {
         let devicetypes: [DeviceType]
     }
 
-    struct DeviceType: Decodable {
+    struct DeviceType: Decodable, Hashable {
         let bundlePath: String
         let name: String
         let identifier: String
@@ -29,12 +29,12 @@ extension SimCtl {
         }
     }
 
-    struct DeviceList: Decodable {
+    struct DeviceList: Decodable, Equatable {
         let devices: [String: [Device]]
     }
 
-    struct Device: Decodable {
-        let status: String?
+    struct Device: Decodable, Equatable {
+        let state: String?
         let isAvailable: Bool
         let name: String
         let udid: String

--- a/ControlRoom/SimulatorSidebarView.swift
+++ b/ControlRoom/SimulatorSidebarView.swift
@@ -11,8 +11,20 @@ import SwiftUI
 struct SimulatorSidebarView: View {
     let simulator: Simulator
 
+    private var statusImage: NSImage {
+        let name: NSImage.Name
+        switch simulator.state {
+        case .booting: name = NSImage.statusPartiallyAvailableName
+        case .shuttingDown: name = NSImage.statusPartiallyAvailableName
+        case .booted: name = NSImage.statusAvailableName
+        default: name = NSImage.statusNoneName
+        }
+        return NSImage(named: name)!
+    }
+
     var body: some View {
-        HStack {
+        HStack(spacing: 2) {
+            Image(nsImage: statusImage)
             Image(nsImage: simulator.image)
                 .resizable()
                 .aspectRatio(1.0, contentMode: .fit)


### PR DESCRIPTION
This adds the concept of "device state", which corresponds to whether the simulator has booted or is shutdown (there are a number of possible states, but those are the main ones).

This state is kept fresh by polling `simctl` every 5 seconds for new information. Controls for non-booted simulators are disabled

<img width="1058" alt="Screen Shot 2020-02-13 at 6 38 11 PM" src="https://user-images.githubusercontent.com/112699/74493693-11da5580-4e90-11ea-8b60-424dee39e200.png">