### PR TITLE
Swift Lint v0.33.1 was causing a build error for types with underscores.

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,3 +1,5 @@
+type_name:
+  allowed_symbols: "_"
 identifier_name:
   min_length: 2
 line_length:


### PR DESCRIPTION
Resolved via a yml file change.