### PR TITLE
Use CoreSimulator framework, when possible

### DIFF
--- a/ControlRoom.xcodeproj/project.pbxproj
+++ b/ControlRoom.xcodeproj/project.pbxproj
@@ -33,6 +33,10 @@
 		551F8CF923F4C45A0006D1BD /* SimulatorSidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551F8CF823F4C45A0006D1BD /* SimulatorSidebarView.swift */; };
 		551F8CFE23F5C9EF0006D1BD /* SimCtl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551F8CFD23F5C9EF0006D1BD /* SimCtl.swift */; };
 		551F8D0023F5CB3A0006D1BD /* SimCtl+Types.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551F8CFF23F5CB3A0006D1BD /* SimCtl+Types.swift */; };
+		555A145723F707E700313BC5 /* CoreSimulator.m in Sources */ = {isa = PBXBuildFile; fileRef = 555A145623F707E700313BC5 /* CoreSimulator.m */; };
+		555A145A23F70A5100313BC5 /* CoreSimulator.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 555A145923F70A5100313BC5 /* CoreSimulator.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		555A145C23F70CCF00313BC5 /* Process.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555A145B23F70CCF00313BC5 /* Process.swift */; };
+		555A145E23F70E8600313BC5 /* CoreSimulatorPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555A145D23F70E8600313BC5 /* CoreSimulatorPublisher.swift */; };
 		70BE435A23F54B7200FD6282 /* LocationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70BE435923F54B7200FD6282 /* LocationView.swift */; };
 		70BE435C23F54C8600FD6282 /* MapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70BE435B23F54C8600FD6282 /* MapView.swift */; };
 /* End PBXBuildFile section */
@@ -67,6 +71,12 @@
 		551F8CF823F4C45A0006D1BD /* SimulatorSidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulatorSidebarView.swift; sourceTree = "<group>"; };
 		551F8CFD23F5C9EF0006D1BD /* SimCtl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimCtl.swift; sourceTree = "<group>"; };
 		551F8CFF23F5CB3A0006D1BD /* SimCtl+Types.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SimCtl+Types.swift"; sourceTree = "<group>"; };
+		555A145423F707E700313BC5 /* ControlRoom-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ControlRoom-Bridging-Header.h"; sourceTree = "<group>"; };
+		555A145523F707E700313BC5 /* CoreSimulator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreSimulator.h; sourceTree = "<group>"; };
+		555A145623F707E700313BC5 /* CoreSimulator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CoreSimulator.m; sourceTree = "<group>"; };
+		555A145923F70A5100313BC5 /* CoreSimulator.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreSimulator.framework; path = /Library/Developer/PrivateFrameworks/CoreSimulator.framework; sourceTree = "<absolute>"; };
+		555A145B23F70CCF00313BC5 /* Process.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Process.swift; sourceTree = "<group>"; };
+		555A145D23F70E8600313BC5 /* CoreSimulatorPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreSimulatorPublisher.swift; sourceTree = "<group>"; };
 		70BE435923F54B7200FD6282 /* LocationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationView.swift; sourceTree = "<group>"; };
 		70BE435B23F54C8600FD6282 /* MapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -76,6 +86,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				555A145A23F70A5100313BC5 /* CoreSimulator.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -87,6 +98,7 @@
 			children = (
 				511BA57B23F3FFEA00E3E660 /* ControlRoom */,
 				511BA57A23F3FFEA00E3E660 /* Products */,
+				555A145823F70A5100313BC5 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -115,6 +127,8 @@
 				551F8CFF23F5CB3A0006D1BD /* SimCtl+Types.swift */,
 				511BA59723F4096800E3E660 /* Simulator.swift */,
 				551F8CF023F498C30006D1BD /* SimulatorsController.swift */,
+				555A145D23F70E8600313BC5 /* CoreSimulatorPublisher.swift */,
+				555A145323F707D900313BC5 /* Objective-C */,
 			);
 			path = ControlRoom;
 			sourceTree = "<group>";
@@ -170,6 +184,7 @@
 				511BA5A523F420AB00E3E660 /* FormSpacer.swift */,
 				51760B2C23F46073004532A9 /* Defaults.swift */,
 				551F8CF623F4BEAC0006D1BD /* TypeIdentifier.swift */,
+				555A145B23F70CCF00313BC5 /* Process.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -181,6 +196,24 @@
 				511BA58F23F4030D00E3E660 /* LoadingView.swift */,
 			);
 			path = Loading;
+			sourceTree = "<group>";
+		};
+		555A145323F707D900313BC5 /* Objective-C */ = {
+			isa = PBXGroup;
+			children = (
+				555A145423F707E700313BC5 /* ControlRoom-Bridging-Header.h */,
+				555A145523F707E700313BC5 /* CoreSimulator.h */,
+				555A145623F707E700313BC5 /* CoreSimulator.m */,
+			);
+			path = "Objective-C";
+			sourceTree = "<group>";
+		};
+		555A145823F70A5100313BC5 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				555A145923F70A5100313BC5 /* CoreSimulator.framework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -216,6 +249,7 @@
 				TargetAttributes = {
 					511BA57823F3FFEA00E3E660 = {
 						CreatedOnToolsVersion = 11.3.1;
+						LastSwiftMigration = 1130;
 					};
 				};
 			};
@@ -297,9 +331,12 @@
 				511BA59423F4079500E3E660 /* Command.swift in Sources */,
 				511BA5A623F420AB00E3E660 /* FormSpacer.swift in Sources */,
 				70BE435A23F54B7200FD6282 /* LocationView.swift in Sources */,
+				555A145723F707E700313BC5 /* CoreSimulator.m in Sources */,
 				51760B2D23F46073004532A9 /* Defaults.swift in Sources */,
+				555A145C23F70CCF00313BC5 /* Process.swift in Sources */,
 				511BA59023F4030D00E3E660 /* LoadingView.swift in Sources */,
 				511BA59623F408F800E3E660 /* LoadingFailedView.swift in Sources */,
+				555A145E23F70E8600313BC5 /* CoreSimulatorPublisher.swift in Sources */,
 				551F8CF523F4AF7B0006D1BD /* FilterField.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -435,6 +472,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = ControlRoom/ControlRoom.entitlements;
 				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
@@ -443,6 +481,10 @@
 				DEVELOPMENT_TEAM = B5C26XE59E;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					/Library/Developer/PrivateFrameworks,
+				);
 				INFOPLIST_FILE = ControlRoom/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -451,6 +493,8 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				PRODUCT_BUNDLE_IDENTIFIER = com.hackingwithswift.ControlRoom;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "ControlRoom/Objective-C/ControlRoom-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
@@ -459,6 +503,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = ControlRoom/ControlRoom.entitlements;
 				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
@@ -467,6 +512,10 @@
 				DEVELOPMENT_TEAM = B5C26XE59E;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					/Library/Developer/PrivateFrameworks,
+				);
 				INFOPLIST_FILE = ControlRoom/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -475,6 +524,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				PRODUCT_BUNDLE_IDENTIFIER = com.hackingwithswift.ControlRoom;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "ControlRoom/Objective-C/ControlRoom-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;

--- a/ControlRoom/Command.swift
+++ b/ControlRoom/Command.swift
@@ -20,23 +20,11 @@ enum Command {
     /// Runs one command using Process, and sends the result or error back on the main thread.
     static func run(command: String, arguments: [String], completion: ((Result<Data, CommandError>) -> Void)? = nil) {
         DispatchQueue.global(qos: .userInitiated).async {
-            let task = Process()
-            task.launchPath = command
-            task.arguments = arguments
-            print(arguments)
-
-            let pipe = Pipe()
-            task.standardOutput = pipe
-
-            do {
-                try task.run()
-                let data = pipe.fileHandleForReading.readDataToEndOfFile()
-
-                DispatchQueue.main.async {
+            let result = Process.execute(command, arguments: arguments)
+            DispatchQueue.main.async {
+                if let data = result {
                     completion?(.success(data))
-                }
-            } catch {
-                DispatchQueue.main.async {
+                } else {
                     completion?(.failure(.missingCommand))
                 }
             }

--- a/ControlRoom/CoreSimulatorPublisher.swift
+++ b/ControlRoom/CoreSimulatorPublisher.swift
@@ -1,0 +1,54 @@
+//
+//  CoreSimulatorPublisher.swift
+//  ControlRoom
+//
+//  Created by Dave DeLong on 2/14/20.
+//  Copyright © 2020 Paul Hudson. All rights reserved.
+//
+
+import Combine
+
+enum CoreSimulatorError: Error {
+    case missingFramework
+}
+
+// Thanks to @avanderlee for this great overview: https://www.avanderlee.com/swift/custom-combine-publisher/
+
+/// A custom subscription to monitor for notifications from CoreSimulator.
+final class CoreSimulatorSubscription<SubscriberType: Subscriber>: Subscription where SubscriberType.Input == Void, SubscriberType.Failure == CoreSimulatorError {
+    private var token: UInt?
+
+    init(subscriber: SubscriberType) {
+        let registrationToken = CoreSimulator.register {
+            _ = subscriber.receive()
+        }
+
+        if registrationToken == NSNotFound {
+            token = nil
+            subscriber.receive(completion: .failure(CoreSimulatorError.missingFramework))
+        } else {
+            token = registrationToken
+        }
+    }
+
+    func request(_ demand: Subscribers.Demand) {
+        // We do nothing here as we only want to send events when they occur.
+        // See, for more info: https://developer.apple.com/documentation/combine/subscribers/demand
+    }
+
+    func cancel() {
+        if let registrationToken = token {
+            CoreSimulator.unregister(fromSimulatorNotifications: registrationToken)
+        }
+    }
+}
+
+struct CoreSimulatorPublisher: Publisher {
+    typealias Output = Void
+    typealias Failure = CoreSimulatorError
+
+    func receive<S>(subscriber: S) where S: Subscriber, S.Input == CoreSimulatorPublisher.Output, S.Failure == CoreSimulatorPublisher.Failure {
+        let subscription = CoreSimulatorSubscription(subscriber: subscriber)
+        subscriber.receive(subscription: subscription)
+    }
+}

--- a/ControlRoom/Helpers/Process.swift
+++ b/ControlRoom/Helpers/Process.swift
@@ -1,0 +1,29 @@
+//
+//  Process.swift
+//  ControlRoom
+//
+//  Created by Dave DeLong on 2/14/20.
+//  Copyright © 2020 Paul Hudson. All rights reserved.
+//
+
+import Foundation
+
+extension Process {
+    @objc
+    static func execute(_ command: String, arguments: [String]) -> Data? {
+        let task = Process()
+        task.launchPath = command
+        task.arguments = arguments
+
+        let pipe = Pipe()
+        task.standardOutput = pipe
+
+        do {
+            try task.run()
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            return data
+        } catch {
+            return nil
+        }
+    }
+}

--- a/ControlRoom/Objective-C/ControlRoom-Bridging-Header.h
+++ b/ControlRoom/Objective-C/ControlRoom-Bridging-Header.h
@@ -1,0 +1,5 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+
+#import "CoreSimulator.h"

--- a/ControlRoom/Objective-C/CoreSimulator.h
+++ b/ControlRoom/Objective-C/CoreSimulator.h
@@ -1,0 +1,24 @@
+//
+//  CoreSimulator.h
+//  ControlRoom
+//
+//  Created by Dave DeLong on 2/14/20.
+//  Copyright © 2020 Paul Hudson. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface CoreSimulator: NSObject
+
+@property (class, readonly) BOOL canRegisterForSimulatorNotifications;
+
++ (NSUInteger)registerForSimulatorNotifications:(void(^)(void))handler;
++ (void)unregisterFromSimulatorNotifications:(NSUInteger)token;
+
+- (instancetype)init NS_UNAVAILABLE;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ControlRoom/Objective-C/CoreSimulator.m
+++ b/ControlRoom/Objective-C/CoreSimulator.m
@@ -1,0 +1,77 @@
+//
+//  CoreSimulator.m
+//  ControlRoom
+//
+//  Created by Dave DeLong on 2/14/20.
+//  Copyright © 2020 Paul Hudson. All rights reserved.
+//
+
+#import "CoreSimulator.h"
+#import "ControlRoom-Swift.h"
+
+/*
+ This file uses private API in the CoreSimulator framework, which is located at /Library/Developer/PrivateFrameworks.
+
+ The build settings for the project are modified to look inside /Library/Developer/PrivateFrameworks when linking,
+ and they also specify to *weakly* link in CoreSimulator (ie, it's an "optional" framework).
+
+ This means that if the app is run on a system that does not have CoreSimulator, then the symbols we need from it
+ will all be nil.
+
+ This allows us to dynamically check for the framework's existence (using NSClassFromString),
+ and alter our behavior in the case that the framework is not properly loaded.
+ */
+
+/// A protocol to describe a "SimDeviceSet"
+///
+/// This is a class defined in CoreSimulator.framework that notifies registrants of changes to the simulators
+@protocol SimDeviceSet_Protocol <NSObject>
+- (NSUInteger)registerNotificationHandler:(void (^_Nonnull)(NSDictionary *))handler;
+- (void)unregisterNotificationHandler:(NSUInteger)token error:(NSError **)error;
+@end
+
+/// A protocol to describe a "SimServiceContext"
+///
+/// This is how we can retrieve the SimDeviceSet
+@protocol SimServiceContext_Protocol <NSObject>
++ (instancetype)sharedServiceContextForDeveloperDir:(NSString *)developerDirectory error:(NSError **)error;
+- (id<SimDeviceSet_Protocol>)defaultDeviceSetWithError:(NSError **)error;
+@end
+
+id<SimDeviceSet_Protocol> deviceSet() {
+    static id<SimDeviceSet_Protocol> set;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        // run `xcode-select -p` to get the active developer directory
+        NSData *select = [NSTask execute:@"/usr/bin/xcode-select" arguments:@[@"-p"]];
+        if (select == nil) { return; }
+
+        NSString *developerDir = [[NSString alloc] initWithData:select encoding:NSUTF8StringEncoding];
+
+        // if CoreSimulator isn't loaded, this will return nil
+        id<SimServiceContext_Protocol> context = [NSClassFromString(@"SimServiceContext") sharedServiceContextForDeveloperDir:developerDir error:nil];
+        set = [context defaultDeviceSetWithError:nil];
+    });
+    return set;
+}
+
+@implementation CoreSimulator
+
++ (BOOL)canRegisterForSimulatorNotifications {
+    return deviceSet() != nil;
+}
+
++ (NSUInteger)registerForSimulatorNotifications:(void (^)(void))handler {
+    if (self.canRegisterForSimulatorNotifications == NO) { return NSNotFound; }
+    return [deviceSet() registerNotificationHandler:^(id info) {
+        handler();
+    }];
+}
+
++ (void)unregisterFromSimulatorNotifications:(NSUInteger)token {
+    [deviceSet() unregisterNotificationHandler:token error:nil];
+}
+
+@end
+
+

--- a/ControlRoom/SimulatorsController.swift
+++ b/ControlRoom/SimulatorsController.swift
@@ -59,7 +59,7 @@ class SimulatorsController: ObservableObject {
     private func loadSimulators() {
         loadingStatus = .loading
 
-        let devices = SimCtl.pollDeviceList()
+        let devices = SimCtl.watchDeviceList()
         let deviceTypes = SimCtl.listDeviceTypes()
         let runtimes = SimCtl.listRuntimes()
 


### PR DESCRIPTION
CoreSimulator is a private framework we can use to be notified of changes to the simulators, without having to poll every 5 seconds. We bridge this functionality into the app from Objective-C by way of a custom Combine publisher, which makes it seamlessly fit in with the existing publishers.

We fall back to polling for information in the case that CoreSimulator cannot be loaded.