### PR TITLE
Adds support for selecting multiple simulators.

### DIFF
--- a/ControlRoom/Command.swift
+++ b/ControlRoom/Command.swift
@@ -36,4 +36,10 @@ enum Command {
         let arguments = ["simctl"] + arguments
         Command.run(command: "/usr/bin/xcrun", arguments: arguments, completion: completion)
     }
+
+    /// Swift doesn't have array splatting yet, so this needs to exist to complement the variadic option above.
+    static func simctl(_ arguments: [String], completion: ((Result<Data, CommandError>) -> Void)? = nil) {
+        let arguments = ["simctl"] + arguments
+        Command.run(command: "/usr/bin/xcrun", arguments: arguments, completion: completion)
+    }
 }

--- a/ControlRoom/SidebarView.swift
+++ b/ControlRoom/SidebarView.swift
@@ -15,12 +15,19 @@ struct SidebarView: View {
     var body: some View {
         GeometryReader { _ in
             VStack(spacing: 0) {
-                List(selection: self.$controller.selectedSimulatorID) {
+                List(selection: self.$controller.selectedSimulatorIDs) {
                     if self.controller.simulators.isEmpty {
                         Text("No simulators")
                     } else {
                         ForEach(Simulator.Platform.allCases, id: \.self) { platform in
                             self.section(for: platform)
+                        }
+                    }
+                }
+                .contextMenu {
+                    if self.controller.selectedSimulatorIDs.count > 0 {
+                        Button("Delete") {
+                            self.deleteSelectedSimulators()
                         }
                     }
                 }
@@ -60,6 +67,12 @@ struct SidebarView: View {
                 }
             }
         }
+    }
+
+    /// Deletes all simulators that are currently selected.
+    func deleteSelectedSimulators() {
+        guard controller.selectedSimulatorIDs.count > 0 else { return }
+        Command.simctl(["delete"] + controller.selectedSimulatorIDs)
     }
 }
 

--- a/ControlRoom/SimulatorsController.swift
+++ b/ControlRoom/SimulatorsController.swift
@@ -45,13 +45,15 @@ class SimulatorsController: ObservableObject {
         didSet { filterSimulators() }
     }
 
-    /// The simulator the user is actively working with.
-    var selectedSimulatorID: String? {
+    /// The simulators the user has selected to work with. If this has one item then
+    /// they are working with a simulator; if more than one they are probably about
+    /// to delete several at a time.
+    var selectedSimulatorIDs = Set<String>() {
         willSet { objectWillChange.send() }
     }
 
     var selectedSimulator: Simulator? {
-        allSimulators.first(where: { $0.udid == selectedSimulatorID })
+        allSimulators.first(where: { $0.udid == selectedSimulatorIDs.first })
     }
 
     private var cancellables = Set<AnyCancellable>()
@@ -138,12 +140,12 @@ class SimulatorsController: ObservableObject {
             if simulators.firstIndex(of: current) == nil {
                 // the current simulator is not in the list of filtered simulators
                 // deselect it
-                selectedSimulatorID = nil
+                selectedSimulatorIDs = []
             }
         }
 
-        if selectedSimulator == nil {
-            selectedSimulatorID = simulators.first?.udid
+        if selectedSimulator == nil, let firstID = simulators.first?.udid {
+            selectedSimulatorIDs = [firstID]
         }
     }
 }

--- a/ControlRoom/SplitLayoutView.swift
+++ b/ControlRoom/SplitLayoutView.swift
@@ -21,12 +21,12 @@ struct SplitLayoutView: View {
             // otherwise the view would collapse down to (potentially)
             // the size of the Text.
             GeometryReader { _ in
-                if self.controller.selectedSimulator == nil {
-                    Text("Select a simulator from the list.")
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                } else {
+                if self.controller.selectedSimulatorIDs.count == 1 {
                     ControlView(simulator: self.controller.selectedSimulator!)
                         .padding()
+                } else {
+                    Text("Select a simulator from the list.")
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
                 }
             }
         }


### PR DESCRIPTION
This allows the user to select multiple simulators from the left-hand sidebar, specifically to make deleting easier. As soon as they select anything other than one simulator (i.e. zero or many) the detail view goes away – it might be nice to think about manipulating many simulators at once, but that's a separate issue. To enable deleting, this adds a context menu to the simulator list; given the destructive nature of this change it could probably use a confirmation option.

Fixes #29.