### PR TITLE
Add uninstall confirmation

### DIFF
--- a/ControlRoom/Simulator UI/ControlScreens/AppView.swift
+++ b/ControlRoom/Simulator UI/ControlScreens/AppView.swift
@@ -37,6 +37,9 @@ struct AppView: View {
     }
     """
 
+    /// If true shows the unistall confirmation alert.
+    @State private var shouldShowUnistallConfirmationAlert: Bool = false
+
     /// All permission options supported by the simulator.
     let resetPermissions = [
         "All",
@@ -70,7 +73,7 @@ struct AppView: View {
                         HStack {
                             Toggle("Show system apps", isOn: $shouldDisplaySystemApps.onChange(storeShouldShouldShowSystemApps))
                             Button("Show Container", action: showContainer)
-                            Button("Uninstall App", action: uninstallApp)
+                            Button("Uninstall App") { self.shouldShowUnistallConfirmationAlert = true }
                         }
                     }
                     AppSummaryView(application: selectedApplication)
@@ -117,6 +120,12 @@ struct AppView: View {
             Text("App")
         }
         .padding()
+        .alert(isPresented: $shouldShowUnistallConfirmationAlert) {
+            Alert(title: Text("Are you sure you want to permanently delete \(selectedApplication.displayName)"),
+                  message: Text("You can’t undo this action."),
+                  primaryButton: .destructive(Text("Delete the app"), action: uninstallApp),
+                  secondaryButton: .default(Text("Cancel")))
+        }
     }
 
     /// Reveals the app's container directory in Finder,

--- a/ControlRoom/Simulator UI/ControlScreens/AppView.swift
+++ b/ControlRoom/Simulator UI/ControlScreens/AppView.swift
@@ -37,8 +37,8 @@ struct AppView: View {
     }
     """
 
-    /// If true shows the unistall confirmation alert.
-    @State private var shouldShowUnistallConfirmationAlert: Bool = false
+    /// If true shows the uninstall confirmation alert.
+    @State private var shouldShowUninstallConfirmationAlert: Bool = false
 
     private var isApplicationSelected: Bool {
         !selectedApplication.bundleIdentifier.isEmpty
@@ -77,7 +77,7 @@ struct AppView: View {
                         HStack {
                             Toggle("Show system apps", isOn: $shouldDisplaySystemApps.onChange(storeShouldShouldShowSystemApps))
                             Button("Show Container", action: showContainer)
-                            Button("Uninstall App") { self.shouldShowUnistallConfirmationAlert = true }
+                            Button("Uninstall App") { self.shouldShowUninstallConfirmationAlert = true }
                         }
                         .disabled(!isApplicationSelected)
                     }
@@ -126,7 +126,7 @@ struct AppView: View {
             Text("App")
         }
         .padding()
-        .alert(isPresented: $shouldShowUnistallConfirmationAlert) {
+        .alert(isPresented: $shouldShowUninstallConfirmationAlert) {
             Alert(title: Text("Are you sure you want to permanently delete \(selectedApplication.displayName)"),
                   message: Text("You can’t undo this action."),
                   primaryButton: .destructive(Text("Delete the app"), action: uninstallApp),

--- a/ControlRoom/Simulator UI/ControlScreens/AppView.swift
+++ b/ControlRoom/Simulator UI/ControlScreens/AppView.swift
@@ -115,6 +115,7 @@ struct AppView: View {
                 HStack {
                     Spacer()
                     Button("Send Push Notification", action: sendPushNotification)
+                        .disabled(!isApplicationSelected)
                 }
             }
 

--- a/ControlRoom/Simulator UI/ControlScreens/AppView.swift
+++ b/ControlRoom/Simulator UI/ControlScreens/AppView.swift
@@ -40,6 +40,10 @@ struct AppView: View {
     /// If true shows the unistall confirmation alert.
     @State private var shouldShowUnistallConfirmationAlert: Bool = false
 
+    private var isApplicationSelected: Bool {
+        !selectedApplication.bundleIdentifier.isEmpty
+    }
+
     /// All permission options supported by the simulator.
     let resetPermissions = [
         "All",
@@ -75,6 +79,7 @@ struct AppView: View {
                             Button("Show Container", action: showContainer)
                             Button("Uninstall App") { self.shouldShowUnistallConfirmationAlert = true }
                         }
+                        .disabled(!isApplicationSelected)
                     }
                     AppSummaryView(application: selectedApplication)
                 }


### PR DESCRIPTION
This PR adds a confirmation alert when the users taps on "Uninstall App" fixing https://github.com/twostraws/ControlRoom/issues/26 and also disable the app-related controls when the app is not selected.