### PR TITLE
Add simulator delete confirmation alert

### DIFF
--- a/ControlRoom/Main Window/SidebarView.swift
+++ b/ControlRoom/Main Window/SidebarView.swift
@@ -12,6 +12,10 @@ import SwiftUI
 struct SidebarView: View {
     @ObservedObject var controller: SimulatorsController
 
+    private var selectedSimulator: Simulator? {
+        controller.selectedSimulators.first
+    }
+
     var body: some View {
         GeometryReader { _ in
             VStack(spacing: 0) {
@@ -21,13 +25,6 @@ struct SidebarView: View {
                     } else {
                         ForEach(Simulator.Platform.allCases, id: \.self) { platform in
                             self.section(for: platform)
-                        }
-                    }
-                }
-                .contextMenu {
-                    if self.controller.selectedSimulatorIDs.count > 0 {
-                        Button("Delete") {
-                            self.deleteSelectedSimulators()
                         }
                     }
                 }
@@ -67,12 +64,6 @@ struct SidebarView: View {
                 }
             }
         }
-    }
-
-    /// Deletes all simulators that are currently selected.
-    func deleteSelectedSimulators() {
-        guard controller.selectedSimulatorIDs.count > 0 else { return }
-        SimCtl.delete(controller.selectedSimulatorIDs)
     }
 }
 

--- a/ControlRoom/Main Window/SimulatorSidebarView.swift
+++ b/ControlRoom/Main Window/SimulatorSidebarView.swift
@@ -12,8 +12,6 @@ import SwiftUI
 struct SimulatorSidebarView: View {
     let simulator: Simulator
 
-    @State private var shouldShowDeleteAlert = false
-
     private var simulatorSummary: String {
         [simulator.name, simulator.runtime?.name]
             .compactMap { $0 }
@@ -43,22 +41,6 @@ struct SimulatorSidebarView: View {
             Text(simulator.name)
             Spacer()
         }
-        .contextMenu {
-            Button("Delete") {
-                self.shouldShowDeleteAlert = true
-            }
-        }
-        .alert(isPresented: $shouldShowDeleteAlert) {
-            Alert(title: Text("Are you sure you want to permanently delete \(simulatorSummary)?"),
-                  message: Text("You can’t undo this action."),
-                  primaryButton: .destructive(Text("Delete the simulator"), action: deleteSelectedSimulator),
-                  secondaryButton: .default(Text("Cancel")))
-        }
-    }
-
-    /// Deletes all simulators that are currently selected.
-    private func deleteSelectedSimulator() {
-        SimCtl.delete([simulator.udid])
     }
 }
 

--- a/ControlRoom/Main Window/SimulatorSidebarView.swift
+++ b/ControlRoom/Main Window/SimulatorSidebarView.swift
@@ -12,6 +12,14 @@ import SwiftUI
 struct SimulatorSidebarView: View {
     let simulator: Simulator
 
+    @State private var shouldShowDeleteAlert = false
+
+    private var simulatorSummary: String {
+        [simulator.name, simulator.runtime?.name]
+            .compactMap { $0 }
+            .joined(separator: " - ")
+    }
+
     private var statusImage: NSImage {
         let name: NSImage.Name
 
@@ -35,6 +43,22 @@ struct SimulatorSidebarView: View {
             Text(simulator.name)
             Spacer()
         }
+        .contextMenu {
+            Button("Delete") {
+                self.shouldShowDeleteAlert = true
+            }
+        }
+        .alert(isPresented: $shouldShowDeleteAlert) {
+            Alert(title: Text("Are you sure you want to permanently delete \(simulatorSummary)?"),
+                  message: Text("You can’t undo this action."),
+                  primaryButton: .destructive(Text("Delete the simulator"), action: deleteSelectedSimulator),
+                  secondaryButton: .default(Text("Cancel")))
+        }
+    }
+
+    /// Deletes all simulators that are currently selected.
+    private func deleteSelectedSimulator() {
+        SimCtl.delete([simulator.udid])
     }
 }
 


### PR DESCRIPTION
This PR adds a confirmation alert when the users select on "Delete" from the simulator context menu.