### PR TITLE
Contextual actions

### DIFF
--- a/ControlRoom.xcodeproj/project.pbxproj
+++ b/ControlRoom.xcodeproj/project.pbxproj
@@ -36,6 +36,8 @@
 		555A145A23F70A5100313BC5 /* CoreSimulator.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 555A145923F70A5100313BC5 /* CoreSimulator.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		555A145C23F70CCF00313BC5 /* Process.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555A145B23F70CCF00313BC5 /* Process.swift */; };
 		555A145E23F70E8600313BC5 /* CoreSimulatorPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555A145D23F70E8600313BC5 /* CoreSimulatorPublisher.swift */; };
+		55DF68B723F856E100E717D3 /* SimulatorActionSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DF68B623F856E100E717D3 /* SimulatorActionSheet.swift */; };
+		55DF68B923F86C0700E717D3 /* ContextMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DF68B823F86C0700E717D3 /* ContextMenu.swift */; };
 		70BE435A23F54B7200FD6282 /* LocationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70BE435923F54B7200FD6282 /* LocationView.swift */; };
 		70BE435C23F54C8600FD6282 /* MapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70BE435B23F54C8600FD6282 /* MapView.swift */; };
 		ACDF076623F7D1C300597B3B /* Application.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACDF076523F7D1C300597B3B /* Application.swift */; };
@@ -77,6 +79,8 @@
 		555A145923F70A5100313BC5 /* CoreSimulator.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreSimulator.framework; path = /Library/Developer/PrivateFrameworks/CoreSimulator.framework; sourceTree = "<absolute>"; };
 		555A145B23F70CCF00313BC5 /* Process.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Process.swift; sourceTree = "<group>"; };
 		555A145D23F70E8600313BC5 /* CoreSimulatorPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreSimulatorPublisher.swift; sourceTree = "<group>"; };
+		55DF68B623F856E100E717D3 /* SimulatorActionSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulatorActionSheet.swift; sourceTree = "<group>"; };
+		55DF68B823F86C0700E717D3 /* ContextMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextMenu.swift; sourceTree = "<group>"; };
 		70BE435923F54B7200FD6282 /* LocationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationView.swift; sourceTree = "<group>"; };
 		70BE435B23F54C8600FD6282 /* MapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapView.swift; sourceTree = "<group>"; };
 		ACDF076523F7D1C300597B3B /* Application.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Application.swift; sourceTree = "<group>"; };
@@ -178,6 +182,7 @@
 				51760B2C23F46073004532A9 /* Defaults.swift */,
 				551F8CF623F4BEAC0006D1BD /* TypeIdentifier.swift */,
 				555A145B23F70CCF00313BC5 /* Process.swift */,
+				55DF68B823F86C0700E717D3 /* ContextMenu.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -216,6 +221,7 @@
 				551F8CEE23F48B030006D1BD /* SplitLayoutView.swift */,
 				551F8CEC23F489A50006D1BD /* SidebarView.swift */,
 				551F8CF823F4C45A0006D1BD /* SimulatorSidebarView.swift */,
+				55DF68B623F856E100E717D3 /* SimulatorActionSheet.swift */,
 			);
 			path = "Main Window";
 			sourceTree = "<group>";
@@ -360,8 +366,10 @@
 				511BA5A623F420AB00E3E660 /* FormSpacer.swift in Sources */,
 				70BE435A23F54B7200FD6282 /* LocationView.swift in Sources */,
 				555A145723F707E700313BC5 /* CoreSimulator.m in Sources */,
+				55DF68B923F86C0700E717D3 /* ContextMenu.swift in Sources */,
 				51760B2D23F46073004532A9 /* Defaults.swift in Sources */,
 				555A145C23F70CCF00313BC5 /* Process.swift in Sources */,
+				55DF68B723F856E100E717D3 /* SimulatorActionSheet.swift in Sources */,
 				511BA59023F4030D00E3E660 /* LoadingView.swift in Sources */,
 				511BA59623F408F800E3E660 /* LoadingFailedView.swift in Sources */,
 				555A145E23F70E8600313BC5 /* CoreSimulatorPublisher.swift in Sources */,

--- a/ControlRoom/Controllers/SimCtl.swift
+++ b/ControlRoom/Controllers/SimCtl.swift
@@ -116,6 +116,14 @@ enum SimCtl {
         execute(["erase", simulator]) { _ in }
     }
 
+    static func clone(_ simulator: String, name: String) {
+        execute(["clone", simulator, name]) { _ in }
+    }
+
+    static func rename(_ simulator: String, name: String) {
+        execute(["rename", simulator, name]) { _ in }
+    }
+
     static func overrideStatusBarBattery(_ simulator: String, level: Int, state: String) {
         execute(["status_bar", simulator, "override", "--batteryLevel", "\(level)", "--batteryState", state]) { _ in }
     }

--- a/ControlRoom/Helpers/ContextMenu.swift
+++ b/ControlRoom/Helpers/ContextMenu.swift
@@ -1,0 +1,18 @@
+//
+//  ContextMenu.swift
+//  ControlRoom
+//
+//  Created by Dave DeLong on 2/15/20.
+//  Copyright © 2020 Paul Hudson. All rights reserved.
+//
+
+import SwiftUI
+
+extension ContextMenu {
+
+    init?(shouldDisplay: Bool, @ViewBuilder menuItems: () -> MenuItems) {
+        guard shouldDisplay == true else { return nil }
+        self.init(menuItems: menuItems)
+    }
+
+}

--- a/ControlRoom/Main Window/SidebarView.swift
+++ b/ControlRoom/Main Window/SidebarView.swift
@@ -44,7 +44,7 @@ struct SidebarView: View {
                 }
                 .contextMenu {
                     if self.controller.selectedSimulatorIDs.count > 0 {
-                        Button("Delete") {
+                        Button("Delete...") {
                             self.shouldShowDeleteAlert = true
                         }
                     }
@@ -66,11 +66,13 @@ struct SidebarView: View {
                     FilterField("Filter", text: self.$controller.filterText)
                 }
                 .padding(2)
-                .alert(isPresented: self.$shouldShowDeleteAlert) {
-                    Alert(title: Text("Are you sure you want to permanently delete \(self.selectedSimulatorsSummary)?"),
-                          message: Text("You can’t undo this action."),
-                          primaryButton: .destructive(Text("Delete"), action: self.deleteSelectedSimulators),
-                          secondaryButton: .default(Text("Cancel")))
+                .sheet(isPresented: self.$shouldShowDeleteAlert) {
+                    SimulatorActionSheet(icon: self.controller.selectedSimulators[0].image,
+                                         message: "Delete Simulators?",
+                                         informativeText: "Are you sure you want to delete the selected simulators? You will not be able to undo this action.",
+                                         confirmationTitle: "Delete",
+                                         confirm: self.deleteSelectedSimulators,
+                                         content: { EmptyView() })
                 }
             }
         }

--- a/ControlRoom/Main Window/SidebarView.swift
+++ b/ControlRoom/Main Window/SidebarView.swift
@@ -54,6 +54,7 @@ struct SidebarView: View {
 
     private func section(for platform: Simulator.Platform) -> some View {
         let simulators = controller.simulators.filter({ $0.platform == platform })
+        let canShowContext = controller.selectedSimulatorIDs.count < 2
 
         return Group {
             if simulators.isEmpty {
@@ -61,7 +62,7 @@ struct SidebarView: View {
             } else {
                 Section(header: Text(platform.displayName.uppercased())) {
                     ForEach(simulators) { simulator in
-                        SimulatorSidebarView(simulator: simulator)
+                        SimulatorSidebarView(simulator: simulator, canShowContextualMenu: canShowContext)
                             .tag(simulator.udid)
                     }
                 }

--- a/ControlRoom/Main Window/SimulatorActionSheet.swift
+++ b/ControlRoom/Main Window/SimulatorActionSheet.swift
@@ -1,0 +1,74 @@
+//
+//  SimulatorActionSheet.swift
+//  ControlRoom
+//
+//  Created by Dave DeLong on 2/15/20.
+//  Copyright © 2020 Paul Hudson. All rights reserved.
+//
+
+import SwiftUI
+
+struct SimulatorActionSheet<Content: View>: View {
+    @Environment(\.presentationMode) var presentationMode
+
+    let icon: NSImage
+    let message: String
+    let informativeText: String
+    let content: Content
+
+    let confirmationTitle: String
+    let confirmationAction: () -> Void
+
+    internal init(icon: NSImage,
+                  message: String,
+                  informativeText: String,
+                  confirmationTitle: String,
+                  confirm: @escaping () -> Void,
+                  @ViewBuilder content: () -> Content) {
+        self.icon = icon
+        self.message = message
+        self.informativeText = informativeText
+        self.content = content()
+        self.confirmationTitle = confirmationTitle
+        self.confirmationAction = confirm
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .top, spacing: 10) {
+                Image(nsImage: icon)
+                    .resizable()
+                    .aspectRatio(icon.size, contentMode: .fit)
+                    .frame(width: 48)
+
+                VStack(alignment: .leading) {
+                    Text(message)
+                        .fontWeight(.bold)
+                        .lineLimit(1)
+
+                    Text(informativeText)
+                        .font(.caption)
+                        .multilineTextAlignment(.leading)
+                }
+            }
+
+            content
+
+            HStack {
+                Button("Cancel", action: self.dismiss)
+                Spacer()
+                Button(confirmationTitle) {
+                    self.confirmationAction()
+                    self.dismiss()
+                }
+            }
+        }
+        .fixedSize(horizontal: false, vertical: true)
+        .frame(minWidth: 300, idealWidth: 400)
+        .padding(20)
+    }
+
+    private func dismiss() {
+        self.presentationMode.wrappedValue.dismiss()
+    }
+}

--- a/ControlRoom/Main Window/SimulatorSidebarView.swift
+++ b/ControlRoom/Main Window/SimulatorSidebarView.swift
@@ -16,6 +16,7 @@ struct SimulatorSidebarView: View {
     enum Action: Int, Identifiable {
         case rename
         case clone
+        case delete
 
         var id: Int { rawValue }
 
@@ -23,6 +24,7 @@ struct SimulatorSidebarView: View {
             switch self {
             case .rename: return "Rename Simulator"
             case .clone: return "Clone Simulator"
+            case .delete: return "Delete Simulator"
             }
         }
 
@@ -30,6 +32,7 @@ struct SimulatorSidebarView: View {
             switch self {
             case .rename: return "Enter a new name for this simulator. It may be the same as the name of an existing simulator, but a unique name will make it easier to identify."
             case .clone: return "Enter a name for the new simulator. It may be the same as the name of an existing simulator, but a unique name will make it easier to identify."
+            case .delete: return "Are you sure you want to delete this simulator? You will not be able to undo this action."
             }
         }
 
@@ -37,6 +40,7 @@ struct SimulatorSidebarView: View {
             switch self {
             case .rename: return "Rename"
             case .clone: return "Clone"
+            case .delete: return "Delete"
             }
         }
     }
@@ -82,17 +86,27 @@ struct SimulatorSidebarView: View {
         .contextMenu(ContextMenu(shouldDisplay: canShowContextualMenu) {
             Button("Rename...") { self.action = .rename }
             Button("Clone...") { self.action = .clone }
-            Button("Delete") { SimCtl.delete([self.simulator.udid]) }
+                .disabled(simulator.state == .booted)
+            Button("Delete...") { self.action = .delete }
         })
         .sheet(item: self.$action) { action in
-            SimulatorActionSheet(icon: self.simulator.image,
-                                 message: action.sheetTitle,
-                                 informativeText: action.sheetMessage,
-                                 confirmationTitle: action.saveActionTitle,
-                                 confirm: { self.performAction(action) },
-                                 content: {
-                                    TextField("Name", text: self.$newName)
-            })
+            if action == .delete {
+                SimulatorActionSheet(icon: self.simulator.image,
+                                     message: action.sheetTitle,
+                                     informativeText: action.sheetMessage,
+                                     confirmationTitle: action.saveActionTitle,
+                                     confirm: { self.performAction(action) },
+                                     content: { EmptyView() })
+            } else {
+                SimulatorActionSheet(icon: self.simulator.image,
+                                     message: action.sheetTitle,
+                                     informativeText: action.sheetMessage,
+                                     confirmationTitle: action.saveActionTitle,
+                                     confirm: { self.performAction(action) },
+                                     content: {
+                                        TextField("Name", text: self.$newName)
+                })
+            }
         }
     }
 
@@ -101,6 +115,7 @@ struct SimulatorSidebarView: View {
         switch action {
         case .rename: SimCtl.rename(simulator.udid, name: newName)
         case .clone: SimCtl.clone(simulator.udid, name: newName)
+        case .delete: SimCtl.delete([simulator.udid])
         }
     }
 }


### PR DESCRIPTION
This adds contextual actions to rename, clone, and delete simulators.

Some notes:
- A booted simulator cannot be cloned. Therefore if the simulator is booted, the "Clone..." command is disabled
- This contextual menu is on the SidebarSimulatorView, but it is only present when _zero or one_ simulator is selected. If multiple simulators are selected, the contextual menu is disabled and the "Delete..." context menu on the sidebar takes precedence.