### PR TITLE
Add Preferences window

### DIFF
--- a/ControlRoom.xcodeproj/project.pbxproj
+++ b/ControlRoom.xcodeproj/project.pbxproj
@@ -36,6 +36,9 @@
 		555A145A23F70A5100313BC5 /* CoreSimulator.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 555A145923F70A5100313BC5 /* CoreSimulator.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		555A145C23F70CCF00313BC5 /* Process.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555A145B23F70CCF00313BC5 /* Process.swift */; };
 		555A145E23F70E8600313BC5 /* CoreSimulatorPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555A145D23F70E8600313BC5 /* CoreSimulatorPublisher.swift */; };
+		55AF68B523F9CFD600C5D87A /* PreferencesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55AF68B423F9CFD600C5D87A /* PreferencesView.swift */; };
+		55AF68B723F9D2E200C5D87A /* UIState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55AF68B623F9D2E200C5D87A /* UIState.swift */; };
+		55AF68B923F9D32100C5D87A /* MainWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55AF68B823F9D32100C5D87A /* MainWindowController.swift */; };
 		55DF68B723F856E100E717D3 /* SimulatorActionSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DF68B623F856E100E717D3 /* SimulatorActionSheet.swift */; };
 		55DF68B923F86C0700E717D3 /* ContextMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DF68B823F86C0700E717D3 /* ContextMenu.swift */; };
 		70BE435A23F54B7200FD6282 /* LocationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70BE435923F54B7200FD6282 /* LocationView.swift */; };
@@ -79,6 +82,9 @@
 		555A145923F70A5100313BC5 /* CoreSimulator.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreSimulator.framework; path = /Library/Developer/PrivateFrameworks/CoreSimulator.framework; sourceTree = "<absolute>"; };
 		555A145B23F70CCF00313BC5 /* Process.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Process.swift; sourceTree = "<group>"; };
 		555A145D23F70E8600313BC5 /* CoreSimulatorPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreSimulatorPublisher.swift; sourceTree = "<group>"; };
+		55AF68B423F9CFD600C5D87A /* PreferencesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesView.swift; sourceTree = "<group>"; };
+		55AF68B623F9D2E200C5D87A /* UIState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIState.swift; sourceTree = "<group>"; };
+		55AF68B823F9D32100C5D87A /* MainWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainWindowController.swift; sourceTree = "<group>"; };
 		55DF68B623F856E100E717D3 /* SimulatorActionSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulatorActionSheet.swift; sourceTree = "<group>"; };
 		55DF68B823F86C0700E717D3 /* ContextMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextMenu.swift; sourceTree = "<group>"; };
 		70BE435923F54B7200FD6282 /* LocationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationView.swift; sourceTree = "<group>"; };
@@ -120,6 +126,7 @@
 			isa = PBXGroup;
 			children = (
 				555A145F23F758DE00313BC5 /* Main Window */,
+				55AF68B323F9CFC600C5D87A /* Preferences UI */,
 				511BA5D223F456B900E3E660 /* Loading */,
 				555A146223F7628100313BC5 /* Simulator UI */,
 				555A146323F762AD00313BC5 /* Controllers */,
@@ -216,6 +223,7 @@
 		555A145F23F758DE00313BC5 /* Main Window */ = {
 			isa = PBXGroup;
 			children = (
+				55AF68B823F9D32100C5D87A /* MainWindowController.swift */,
 				511BA57E23F3FFEA00E3E660 /* MainView.swift */,
 				551F8CEE23F48B030006D1BD /* SplitLayoutView.swift */,
 				551F8CEC23F489A50006D1BD /* SidebarView.swift */,
@@ -237,6 +245,7 @@
 		555A146323F762AD00313BC5 /* Controllers */ = {
 			isa = PBXGroup;
 			children = (
+				55AF68B623F9D2E200C5D87A /* UIState.swift */,
 				5523A7E023F99D7200F25EEC /* Preferences.swift */,
 				551F8CFD23F5C9EF0006D1BD /* SimCtl.swift */,
 				551F8CFF23F5CB3A0006D1BD /* SimCtl+Types.swift */,
@@ -247,6 +256,14 @@
 				555A145D23F70E8600313BC5 /* CoreSimulatorPublisher.swift */,
 			);
 			path = Controllers;
+			sourceTree = "<group>";
+		};
+		55AF68B323F9CFC600C5D87A /* Preferences UI */ = {
+			isa = PBXGroup;
+			children = (
+				55AF68B423F9CFD600C5D87A /* PreferencesView.swift */,
+			);
+			path = "Preferences UI";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -349,6 +366,7 @@
 				551F8CED23F489A50006D1BD /* SidebarView.swift in Sources */,
 				551F8CEF23F48B030006D1BD /* SplitLayoutView.swift in Sources */,
 				551F8CFE23F5C9EF0006D1BD /* SimCtl.swift in Sources */,
+				55AF68B723F9D2E200C5D87A /* UIState.swift in Sources */,
 				511BA59223F4031F00E3E660 /* ControlView.swift in Sources */,
 				511BA57F23F3FFEA00E3E660 /* MainView.swift in Sources */,
 				511BA5AA23F4316700E3E660 /* TextView.swift in Sources */,
@@ -368,10 +386,12 @@
 				70BE435A23F54B7200FD6282 /* LocationView.swift in Sources */,
 				555A145723F707E700313BC5 /* CoreSimulator.m in Sources */,
 				55DF68B923F86C0700E717D3 /* ContextMenu.swift in Sources */,
+				55AF68B923F9D32100C5D87A /* MainWindowController.swift in Sources */,
 				555A145C23F70CCF00313BC5 /* Process.swift in Sources */,
 				55DF68B723F856E100E717D3 /* SimulatorActionSheet.swift in Sources */,
 				511BA59023F4030D00E3E660 /* LoadingView.swift in Sources */,
 				511BA59623F408F800E3E660 /* LoadingFailedView.swift in Sources */,
+				55AF68B523F9CFD600C5D87A /* PreferencesView.swift in Sources */,
 				555A145E23F70E8600313BC5 /* CoreSimulatorPublisher.swift in Sources */,
 				551F8CF523F4AF7B0006D1BD /* FilterField.swift in Sources */,
 			);

--- a/ControlRoom/AppDelegate.swift
+++ b/ControlRoom/AppDelegate.swift
@@ -7,67 +7,18 @@
 //
 
 import Cocoa
-import Combine
-import SwiftUI
 
 @NSApplicationMain
 class AppDelegate: NSObject, NSApplicationDelegate {
-    var window: NSWindow!
 
-    /// One shared `SimulatorsController` to fetch and filter simulator data only once.
-    let preferences = Preferences()
-
-    lazy var controller: SimulatorsController = SimulatorsController(preferences: preferences)
-
-    var cancellables = Set<AnyCancellable>()
+    lazy var mainWindow: MainWindowController = MainWindowController()
 
     func applicationDidFinishLaunching(_ aNotification: Notification) {
-        // Create the SwiftUI view that provides the window contents.
-        let contentView = MainView(controller: controller)
-            .environmentObject(preferences)
-
-        // Create the window and set the content view. 
-        window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 480, height: 300),
-            styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
-            backing: .buffered, defer: false)
-        window.center()
-        window.setFrameAutosaveName("Main Window")
-        window.contentView = NSHostingView(rootView: contentView)
-        window.makeKeyAndOrderFront(nil)
-        window.title = "Control Room"
-        window.isMovableByWindowBackground = true
-        adjustWindowLevel()
-
-        // note this is a DID change publisher, not a WILL change publisher
-        preferences.objectDidChange.sink(receiveValue: { [weak self] in
-            self?.adjustWindowLevel()
-        }).store(in: &cancellables)
-    }
-
-    private func adjustWindowLevel() {
-        window.level = preferences.wantsFloatingWindow ? .floating : .normal
-    }
-
-    @IBAction func toggleFloatingWindow(_ sender: Any) {
-        preferences.wantsFloatingWindow.toggle()
+        mainWindow.showWindow(self)
     }
 
     func applicationWillTerminate(_ aNotification: Notification) {
         // Insert code here to tear down your application
-    }
-
-}
-
-extension AppDelegate: NSMenuItemValidation {
-
-    func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
-        if menuItem.action == #selector(toggleFloatingWindow(_:)) {
-            menuItem.state = preferences.wantsFloatingWindow ? .on : .off
-            return true
-        }
-
-        return false
     }
 
 }

--- a/ControlRoom/Base.lproj/Main.storyboard
+++ b/ControlRoom/Base.lproj/Main.storyboard
@@ -21,7 +21,11 @@
                                             </connections>
                                         </menuItem>
                                         <menuItem isSeparatorItem="YES" id="VOq-y0-SEH"/>
-                                        <menuItem title="Preferences…" keyEquivalent="," id="BOF-NM-1cW"/>
+                                        <menuItem title="Preferences…" keyEquivalent="," id="BOF-NM-1cW">
+                                            <connections>
+                                                <action selector="showPreferences:" target="Ady-hI-5gd" id="hSx-FU-ZMk"/>
+                                            </connections>
+                                        </menuItem>
                                         <menuItem isSeparatorItem="YES" id="wFC-TO-SCJ"/>
                                         <menuItem title="Services" id="NMo-om-nkz">
                                             <modifierMask key="keyEquivalentModifierMask"/>

--- a/ControlRoom/Controllers/Preferences.swift
+++ b/ControlRoom/Controllers/Preferences.swift
@@ -17,6 +17,9 @@ class Preferences: ObservableObject {
     let userDefaults: UserDefaults
 
     @UserDefault("CRWantsFloatingWindow") var wantsFloatingWindow = false
+
+    @UserDefault("CRSidebar_ShowDefaultSimulator") var showDefaultSimulator = true
+    @UserDefault("CRSidebar_ShowBootedDevicesFirst") var showBootedDevicesFirst = false
     @UserDefault("CRSidebar_ShowOnlyActiveDevices") var shouldShowOnlyActiveDevices = false
     @UserDefault("CRSidebar_FilterText") var filterText = ""
 

--- a/ControlRoom/Controllers/UIState.swift
+++ b/ControlRoom/Controllers/UIState.swift
@@ -9,12 +9,9 @@
 import Combine
 
 class UIState: ObservableObject {
-
     static let shared = UIState()
 
     private init() { }
 
-    @Published var showCreateSimulator = false
     @Published var showPreferences = false
-
 }

--- a/ControlRoom/Controllers/UIState.swift
+++ b/ControlRoom/Controllers/UIState.swift
@@ -1,0 +1,20 @@
+//
+//  UIState.swift
+//  ControlRoom
+//
+//  Created by Dave DeLong on 2/16/20.
+//  Copyright © 2020 Paul Hudson. All rights reserved.
+//
+
+import Combine
+
+class UIState: ObservableObject {
+
+    static let shared = UIState()
+
+    private init() { }
+
+    @Published var showCreateSimulator = false
+    @Published var showPreferences = false
+
+}

--- a/ControlRoom/Main Window/MainView.swift
+++ b/ControlRoom/Main Window/MainView.swift
@@ -11,6 +11,8 @@ import SwiftUI
 /// Hosts a LoadingView followed by the main ControlView, or a LoadingFailedView if simctl failed.
 struct MainView: View {
     @ObservedObject var controller: SimulatorsController
+    @EnvironmentObject var preferences: Preferences
+    @EnvironmentObject var uiState: UIState
 
     var body: some View {
         Group {
@@ -23,6 +25,10 @@ struct MainView: View {
             }
         }
         .frame(minWidth: 500, maxWidth: .infinity, minHeight: 500, maxHeight: .infinity)
+        .sheet(isPresented: $uiState.showPreferences) {
+            PreferencesView()
+                .environmentObject(self.preferences)
+        }
     }
 }
 

--- a/ControlRoom/Main Window/MainWindowController.swift
+++ b/ControlRoom/Main Window/MainWindowController.swift
@@ -1,0 +1,82 @@
+//
+//  MainWindowController.swift
+//  ControlRoom
+//
+//  Created by Dave DeLong on 2/16/20.
+//  Copyright © 2020 Paul Hudson. All rights reserved.
+//
+
+import Cocoa
+import Combine
+import SwiftUI
+
+class MainWindowController: NSWindowController {
+
+    // Without this, AppKit won't call -loadWindow
+    override var windowNibName: NSNib.Name? { "None" }
+
+    lazy var preferences: Preferences = Preferences()
+    lazy var controller: SimulatorsController = SimulatorsController(preferences: preferences)
+
+    private var cancellables = Set<AnyCancellable>()
+
+    init() {
+        super.init(window: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func windowContent() -> some View {
+        MainView(controller: controller)
+            .environmentObject(preferences)
+            .environmentObject(UIState.shared)
+    }
+
+    override func loadWindow() {
+        // Create the window and set the content view.
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 480, height: 300),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
+            backing: .buffered, defer: false)
+        window.setFrameAutosaveName("Main Window")
+        window.contentView = NSHostingView(rootView: windowContent())
+        window.title = "Control Room"
+        window.isMovableByWindowBackground = true
+
+        self.window = window
+        adjustWindowLevel()
+
+        // note this is a DID change publisher, not a WILL change publisher
+        preferences.objectDidChange.sink(receiveValue: { [weak self] in
+            self?.adjustWindowLevel()
+        }).store(in: &cancellables)
+    }
+
+    private func adjustWindowLevel() {
+        window?.level = preferences.wantsFloatingWindow ? .floating : .normal
+    }
+
+    @IBAction func toggleFloatingWindow(_ sender: Any) {
+        preferences.wantsFloatingWindow.toggle()
+    }
+
+    @IBAction func showPreferences(_ sender: Any) {
+        UIState.shared.showPreferences = true
+    }
+
+}
+
+extension MainWindowController: NSMenuItemValidation {
+
+    func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
+        if menuItem.action == #selector(toggleFloatingWindow(_:)) {
+            menuItem.state = preferences.wantsFloatingWindow ? .on : .off
+            return true
+        }
+
+        return responds(to: menuItem.action)
+    }
+
+}

--- a/ControlRoom/Preferences UI/PreferencesView.swift
+++ b/ControlRoom/Preferences UI/PreferencesView.swift
@@ -1,0 +1,36 @@
+//
+//  PreferencesView.swift
+//  ControlRoom
+//
+//  Created by Dave DeLong on 2/16/20.
+//  Copyright © 2020 Paul Hudson. All rights reserved.
+//
+
+import SwiftUI
+
+struct PreferencesView: View {
+    @EnvironmentObject var preferences: Preferences
+    @Environment(\.presentationMode) var presentationMode
+
+    var body: some View {
+        Form {
+
+            Section(header: Text("Main Window")) {
+                Toggle("Keep window on top", isOn: $preferences.wantsFloatingWindow)
+                Toggle("Show Default simulator", isOn: $preferences.showDefaultSimulator)
+                Toggle("Show booted devices first", isOn: $preferences.showBootedDevicesFirst)
+            }
+
+            Button("Done") {
+                self.presentationMode.wrappedValue.dismiss()
+            }
+        }
+        .padding(20)
+    }
+}
+
+struct PreferencesView_Previews: PreviewProvider {
+    static var previews: some View {
+        PreferencesView()
+    }
+}


### PR DESCRIPTION
This adds a preference window (invoked via the app menu and via `⌘,`) to toggle a couple of different app preferences:

- the existing "keep window on top" toggle 
- a new "show default simulator" toggle (related to #43)
- a new "show active simulators first" toggle (fixes #44)

In terms of organization, this PR also:
- moves main window management out to a `MainWindowController`
- Adds a `UIState: ObservableObject` that is used for high-level window management bindings

<img width="918" alt="Screen Shot 2020-02-16 at 1 23 46 PM" src="https://user-images.githubusercontent.com/112699/74612107-919a3700-50bf-11ea-8c61-0fbff730a23e.png">
