### PR TITLE
Fetch selectedApplication using bundleIdentifier from preferences

### DIFF
--- a/ControlRoom/Simulator UI/ControlScreens/AppView.swift
+++ b/ControlRoom/Simulator UI/ControlScreens/AppView.swift
@@ -16,7 +16,10 @@ struct AppView: View {
     var applications: [Application]
 
     /// The selected application we want to manipulate.
-    @State private var selectedApplication: Application = .default
+    private var selectedApplication: Application  {
+        return applications.first(where: { $0.bundleIdentifier == preferences.lastBundleID })
+            ?? .default
+    }
 
     /// The current permission option the user has selected to grant, reset, or revoke.
     @State private var resetPermission = "All"


### PR DESCRIPTION
This [PR](https://github.com/twostraws/ControlRoom/pull/50) adds a `Preferences` to persist some states, including the `selectedApplication`. But the `AppView.selectedApplication` was still using a local `@State`.