### PR TITLE
Fix IO commands syntax

### DIFF
--- a/ControlRoom/Controllers/SimCtl+SubCommands.swift
+++ b/ControlRoom/Controllers/SimCtl+SubCommands.swift
@@ -147,7 +147,7 @@ extension SimCtl {
         }
         /// Set up a device IO operation.
         static func io(deviceId: String, operation: IO.Operation) -> Command {
-            Command("io", arguments: operation.arguments)
+            Command("io", arguments: [deviceId] + operation.arguments)
         }
         /// Collect diagnostic information and logs.
         static func diagnose(flags: [Diagnose.Flag]) -> Command {


### PR DESCRIPTION
Currently the screenshot feature doesn't work (at least for me) because the device id is missing in the command.