### PR TITLE
Add a button to open the app data folder

### DIFF
--- a/ControlRoom/Controllers/Application.swift
+++ b/ControlRoom/Controllers/Application.swift
@@ -50,7 +50,7 @@ struct Application: Hashable {
                      Self.fetchIconNames(plistDitionary: plistDictionary, platformIdentifier: "~ipad")]
             .flatMap { $0 }
             .compactMap { Bundle(url: url)?.urlForImageResource($0) }
-        dataFolderURL = URL(strings: application.dataFolderPath ?? "")
+        dataFolderURL = URL(string: application.dataFolderPath ?? "")
     }
 
     private static func fetchIconNames(plistDitionary: NSDictionary?, platformIdentifier: String = "") -> [String] {

--- a/ControlRoom/Controllers/Application.swift
+++ b/ControlRoom/Controllers/Application.swift
@@ -17,6 +17,7 @@ struct Application: Hashable {
     let versionNumber: String
     let buildNumber: String
     let imageURLs: [URL]?
+    let dataFolderURL: URL?
 
     static let `default` = Application()
 
@@ -28,6 +29,7 @@ struct Application: Hashable {
         versionNumber = ""
         buildNumber = ""
         imageURLs = nil
+        dataFolderURL = nil
     }
 
     init?(application: SimCtl.Application) {
@@ -48,6 +50,7 @@ struct Application: Hashable {
                      Self.fetchIconNames(plistDitionary: plistDictionary, platformIdentifier: "~ipad")]
             .flatMap { $0 }
             .compactMap { Bundle(url: url)?.urlForImageResource($0) }
+        dataFolderURL = URL(strings: application.dataFolderPath ?? "")
     }
 
     private static func fetchIconNames(plistDitionary: NSDictionary?, platformIdentifier: String = "") -> [String] {

--- a/ControlRoom/Controllers/Application.swift
+++ b/ControlRoom/Controllers/Application.swift
@@ -18,6 +18,7 @@ struct Application: Hashable {
     let buildNumber: String
     let imageURLs: [URL]?
     let dataFolderURL: URL?
+    let bundleURL: URL?
 
     static let `default` = Application()
 
@@ -30,6 +31,7 @@ struct Application: Hashable {
         buildNumber = ""
         imageURLs = nil
         dataFolderURL = nil
+        bundleURL = nil
     }
 
     init?(application: SimCtl.Application) {
@@ -51,6 +53,7 @@ struct Application: Hashable {
             .flatMap { $0 }
             .compactMap { Bundle(url: url)?.urlForImageResource($0) }
         dataFolderURL = URL(string: application.dataFolderPath ?? "")
+        bundleURL = URL(string: application.bundlePath ?? "")
     }
 
     private static func fetchIconNames(plistDitionary: NSDictionary?, platformIdentifier: String = "") -> [String] {

--- a/ControlRoom/Controllers/SimCtl+Types.swift
+++ b/ControlRoom/Controllers/SimCtl+Types.swift
@@ -144,6 +144,7 @@ extension SimCtl {
         let bundleIdentifier: String
         let displayName: String
         let bundlePath: String
+        let dataFolderPath: String?
     }
 }
 
@@ -154,5 +155,6 @@ extension SimCtl.Application {
         case bundleIdentifier = "CFBundleIdentifier"
         case displayName = "CFBundleDisplayName"
         case bundlePath = "Bundle"
+        case dataFolderPath = "DataContainer"
     }
 }

--- a/ControlRoom/Simulator UI/ControlScreens/AppView.swift
+++ b/ControlRoom/Simulator UI/ControlScreens/AppView.swift
@@ -121,15 +121,10 @@ struct AppView: View {
 
     /// Reveals the app's bundle directory in Finder.
     func openAppBundle() {
-        SimCtl.getAppContainer(simulator.udid, appID: selectedApplication.bundleIdentifier) { url in
-            // We can't just "open" the app bundle URL, because
-            // macOS will attempt to execute the binary.
-            // So, instead we ask macOS to show the Info.plist file,
-            // which will be just inside the app bundle.
-            if let infoPlist = url?.appendingPathComponent("Info.plist") {
-                NSWorkspace.shared.activateFileViewerSelecting([infoPlist])
-            }
-        }
+        guard
+            let infoPropertyListURL = selectedApplication.bundleURL?.appendingPathComponent("Info.plist")
+            else { return }
+        NSWorkspace.shared.activateFileViewerSelecting([infoPropertyListURL])
     }
 
     /// Sends a JSON string to the device as push notification,

--- a/ControlRoom/Simulator UI/ControlScreens/AppView.swift
+++ b/ControlRoom/Simulator UI/ControlScreens/AppView.swift
@@ -52,8 +52,8 @@ struct AppView: View {
                         .pickerStyle(PopUpButtonPickerStyle())
                         HStack {
                             Toggle("Show system apps", isOn: $preferences.shouldShowSystemApps)
-                            Button("Show container", action: showContainer)
-                            Button("Open app bundle", action: showAppBundle)
+                            Button("Open data folder", action: openDataFolder)
+                            Button("Open app bundle", action: openAppBundle)
                             Button("Uninstall App") { self.shouldShowUninstallConfirmationAlert = true }
                         }
                         .disabled(!isApplicationSelected)
@@ -112,7 +112,7 @@ struct AppView: View {
     }
 
     /// Reveals the app's container directory in Finder.
-    func showContainer() {
+    func openDataFolder() {
         guard
             let dataFolderURL = selectedApplication.dataFolderURL
             else { return }
@@ -120,7 +120,7 @@ struct AppView: View {
     }
 
     /// Reveals the app's bundle directory in Finder.
-    func showAppBundle() {
+    func openAppBundle() {
         SimCtl.getAppContainer(simulator.udid, appID: selectedApplication.bundleIdentifier) { url in
             // We can't just "open" the app bundle URL, because
             // macOS will attempt to execute the binary.

--- a/ControlRoom/Simulator UI/ControlScreens/AppView.swift
+++ b/ControlRoom/Simulator UI/ControlScreens/AppView.swift
@@ -52,7 +52,8 @@ struct AppView: View {
                         .pickerStyle(PopUpButtonPickerStyle())
                         HStack {
                             Toggle("Show system apps", isOn: $preferences.shouldShowSystemApps)
-                            Button("Show Container", action: showContainer)
+                            Button("Show container", action: showContainer)
+                            Button("Open app bundle", action: showAppBundle)
                             Button("Uninstall App") { self.shouldShowUninstallConfirmationAlert = true }
                         }
                         .disabled(!isApplicationSelected)
@@ -110,8 +111,16 @@ struct AppView: View {
         }
     }
 
-    /// Reveals the app's container directory in Finder,
+    /// Reveals the app's container directory in Finder.
     func showContainer() {
+        guard
+            let dataFolderURL = selectedApplication.dataFolderURL
+            else { return }
+        NSWorkspace.shared.activateFileViewerSelecting([dataFolderURL])
+    }
+
+    /// Reveals the app's bundle directory in Finder.
+    func showAppBundle() {
         SimCtl.getAppContainer(simulator.udid, appID: selectedApplication.bundleIdentifier) { url in
             // We can't just "open" the app bundle URL, because
             // macOS will attempt to execute the binary.


### PR DESCRIPTION
Changes:
- "Open data folder" now open the data folder of the selected application
- "Open app bundle" now open the bundle of the selected application.
- The bundle path now is fetched from `listapps` instead of `get_app_container`

This PR fix #57 