### PR TITLE
Add command line tool check

### DIFF
--- a/ControlRoom.xcodeproj/project.pbxproj
+++ b/ControlRoom.xcodeproj/project.pbxproj
@@ -53,6 +53,8 @@
 		AC472CFB240D5F22007FF521 /* NotificationEditorView.strings in Resources */ = {isa = PBXBuildFile; fileRef = AC472CFA240D5F22007FF521 /* NotificationEditorView.strings */; };
 		ACCD798C240ADEE20004ECE5 /* NotificationEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACCD798B240ADEE20004ECE5 /* NotificationEditorView.swift */; };
 		ACCD798E240AE82C0004ECE5 /* PushNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACCD798D240AE82C0004ECE5 /* PushNotification.swift */; };
+		ACD2064D2431F20000F8659B /* CommandLineExecuter.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACD2064C2431F20000F8659B /* CommandLineExecuter.swift */; };
+		ACD206572432272500F8659B /* XcodeCommandLineToolsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACD206562432272500F8659B /* XcodeCommandLineToolsController.swift */; };
 		ACDF076623F7D1C300597B3B /* Application.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACDF076523F7D1C300597B3B /* Application.swift */; };
 		ACDF076823F7E91A00597B3B /* ApplicationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACDF076723F7E91A00597B3B /* ApplicationType.swift */; };
 		B07F584923F99A1700256D5D /* SimCtl+SubCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = B07F584823F99A1700256D5D /* SimCtl+SubCommands.swift */; };
@@ -122,6 +124,8 @@
 		AC472CFA240D5F22007FF521 /* NotificationEditorView.strings */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; path = NotificationEditorView.strings; sourceTree = "<group>"; };
 		ACCD798B240ADEE20004ECE5 /* NotificationEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationEditorView.swift; sourceTree = "<group>"; };
 		ACCD798D240AE82C0004ECE5 /* PushNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotification.swift; sourceTree = "<group>"; };
+		ACD2064C2431F20000F8659B /* CommandLineExecuter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandLineExecuter.swift; sourceTree = "<group>"; };
+		ACD206562432272500F8659B /* XcodeCommandLineToolsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcodeCommandLineToolsController.swift; sourceTree = "<group>"; };
 		ACDF076523F7D1C300597B3B /* Application.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Application.swift; sourceTree = "<group>"; };
 		ACDF076723F7E91A00597B3B /* ApplicationType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationType.swift; sourceTree = "<group>"; };
 		B07F584823F99A1700256D5D /* SimCtl+SubCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SimCtl+SubCommands.swift"; sourceTree = "<group>"; };
@@ -237,13 +241,14 @@
 			isa = PBXGroup;
 			children = (
 				511BA5A123F41A5900E3E660 /* Binding-OnChange.swift */,
-				511BA5A523F420AB00E3E660 /* FormSpacer.swift */,
-				551F8CF623F4BEAC0006D1BD /* TypeIdentifier.swift */,
-				555A145B23F70CCF00313BC5 /* Process.swift */,
-				55DF68B823F86C0700E717D3 /* ContextMenu.swift */,
 				55DF68BC23F8C76800E717D3 /* Collection.swift */,
-				5534157F23FE0514005C0A41 /* RecessedButtonStyle.swift */,
+				ACD2064C2431F20000F8659B /* CommandLineExecuter.swift */,
+				55DF68B823F86C0700E717D3 /* ContextMenu.swift */,
 				5534158523FE1AC4005C0A41 /* Flow.swift */,
+				511BA5A523F420AB00E3E660 /* FormSpacer.swift */,
+				555A145B23F70CCF00313BC5 /* Process.swift */,
+				5534157F23FE0514005C0A41 /* RecessedButtonStyle.swift */,
+				551F8CF623F4BEAC0006D1BD /* TypeIdentifier.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -310,17 +315,18 @@
 		555A146323F762AD00313BC5 /* Controllers */ = {
 			isa = PBXGroup;
 			children = (
-				55AF68B623F9D2E200C5D87A /* UIState.swift */,
-				5523A7E023F99D7200F25EEC /* Preferences.swift */,
-				551F8CFD23F5C9EF0006D1BD /* SimCtl.swift */,
-				551F8CFF23F5CB3A0006D1BD /* SimCtl+Types.swift */,
-				B07F584823F99A1700256D5D /* SimCtl+SubCommands.swift */,
-				ACDF076723F7E91A00597B3B /* ApplicationType.swift */,
-				511BA59723F4096800E3E660 /* Simulator.swift */,
 				ACDF076523F7D1C300597B3B /* Application.swift */,
-				551F8CF023F498C30006D1BD /* SimulatorsController.swift */,
+				ACDF076723F7E91A00597B3B /* ApplicationType.swift */,
 				555A145D23F70E8600313BC5 /* CoreSimulatorPublisher.swift */,
+				5523A7E023F99D7200F25EEC /* Preferences.swift */,
 				ACCD798D240AE82C0004ECE5 /* PushNotification.swift */,
+				551F8CFD23F5C9EF0006D1BD /* SimCtl.swift */,
+				B07F584823F99A1700256D5D /* SimCtl+SubCommands.swift */,
+				551F8CFF23F5CB3A0006D1BD /* SimCtl+Types.swift */,
+				511BA59723F4096800E3E660 /* Simulator.swift */,
+				551F8CF023F498C30006D1BD /* SimulatorsController.swift */,
+				55AF68B623F9D2E200C5D87A /* UIState.swift */,
+				ACD206562432272500F8659B /* XcodeCommandLineToolsController.swift */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -534,11 +540,13 @@
 				511BA5A623F420AB00E3E660 /* FormSpacer.swift in Sources */,
 				ACCD798C240ADEE20004ECE5 /* NotificationEditorView.swift in Sources */,
 				70BE435A23F54B7200FD6282 /* LocationView.swift in Sources */,
+				ACD2064D2431F20000F8659B /* CommandLineExecuter.swift in Sources */,
 				555A145723F707E700313BC5 /* CoreSimulator.m in Sources */,
 				55DF68B923F86C0700E717D3 /* ContextMenu.swift in Sources */,
 				55AF68B923F9D32100C5D87A /* MainWindowController.swift in Sources */,
 				555A145C23F70CCF00313BC5 /* Process.swift in Sources */,
 				55DF68B723F856E100E717D3 /* SimulatorActionSheet.swift in Sources */,
+				ACD206572432272500F8659B /* XcodeCommandLineToolsController.swift in Sources */,
 				5534157E23FE04FA005C0A41 /* AboutView.swift in Sources */,
 				511BA59023F4030D00E3E660 /* LoadingView.swift in Sources */,
 				511BA59623F408F800E3E660 /* LoadingFailedView.swift in Sources */,

--- a/ControlRoom/Controllers/SimCtl+SubCommands.swift
+++ b/ControlRoom/Controllers/SimCtl+SubCommands.swift
@@ -10,11 +10,11 @@ import Foundation
 
 // swiftlint:disable file_length
 extension SimCtl {
-    struct Command {
+    struct Command: CommandLineCommand {
         let arguments: [String]
 
         private init(_ subcommand: String, arguments: [String]) {
-            self.arguments = [subcommand] + arguments
+            self.arguments = ["simctl", subcommand] + arguments
         }
 
         /// Create a new device.

--- a/ControlRoom/Controllers/SimulatorsController.swift
+++ b/ControlRoom/Controllers/SimulatorsController.swift
@@ -23,6 +23,9 @@ class SimulatorsController: ObservableObject {
 
         /// Loading failed
         case failed
+
+        /// Invalid command line tool
+        case invalidCommandLineTool
     }
 
     /// The current loading state; defaults to .loading
@@ -69,7 +72,7 @@ class SimulatorsController: ObservableObject {
                 if tool != .empty {
                     self.loadSimulators()
                 } else {
-                    self.loadingStatus = .failed
+                    self.loadingStatus = .invalidCommandLineTool
                 }
             }
             .store(in: &cancellables)

--- a/ControlRoom/Controllers/SimulatorsController.swift
+++ b/ControlRoom/Controllers/SimulatorsController.swift
@@ -62,11 +62,23 @@ class SimulatorsController: ObservableObject {
 
     init(preferences: Preferences) {
         self.preferences = preferences
-        loadSimulators()
 
-        preferences.objectDidChange.sink(receiveValue: { [weak self] in
-            self?.filterSimulators()
-        }).store(in: &cancellables)
+        XcodeCommandLineToolsController.selectedCommandLineTool()
+            .receive(on: DispatchQueue.main)
+            .sink { tool in
+                if tool != .empty {
+                    self.loadSimulators()
+                } else {
+                    self.loadingStatus = .failed
+                }
+            }
+            .store(in: &cancellables)
+
+        preferences.objectDidChange
+            .sink { [weak self] in
+                self?.filterSimulators()
+            }
+            .store(in: &cancellables)
     }
 
     /// Fetches all simulators from simctl.

--- a/ControlRoom/Controllers/XcodeCommandLineToolsController.swift
+++ b/ControlRoom/Controllers/XcodeCommandLineToolsController.swift
@@ -1,0 +1,113 @@
+//
+//  XcodeCommandLineToolsController.swift
+//  ControlRoom
+//
+//  Created by Mario Iannotta on 30/03/2020.
+//  Copyright © 2020 Paul Hudson. All rights reserved.
+//
+
+import Foundation
+import Combine
+
+struct XcodeCommandLineToolsController {
+
+    static func selectedCommandLineTool() -> AnyPublisher<DeveloperTool, Never> {
+        Publishers.CombineLatest(SystemProfiler.listDeveloperTools(), XcodeSelect.printPath())
+            .replaceError(with: ([], ""))
+            .map { devTools, xcodeSelectResult -> DeveloperTool in
+                for devTool in devTools {
+                    if xcodeSelectResult.contains(devTool.path) {
+                        return devTool
+                    }
+                }
+                return .empty
+            }
+            .eraseToAnyPublisher()
+    }
+
+}
+
+private enum XcodeSelect: CommandLineCommandExecuter {
+
+    typealias Error = CommandLineError
+
+    static var launchPath = "/usr/bin/xcode-select"
+
+    static func printPath() -> AnyPublisher<String, XcodeSelect.Error> {
+        XcodeSelect.executeSubject(.printPath())
+            .compactMap { String(data: $0, encoding: .utf8) }
+            .eraseToAnyPublisher()
+    }
+}
+
+private extension XcodeSelect {
+
+    struct Command: CommandLineCommand {
+        let arguments: [String]
+
+        private init(_ subcommand: String, arguments: [String]) {
+            self.arguments = [subcommand] + arguments
+        }
+
+        /// Print the path of the active developer directory.
+        static func printPath() -> Command {
+            Command("-p", arguments: [])
+        }
+    }
+}
+
+private enum SystemProfiler: CommandLineCommandExecuter {
+
+    typealias Error = CommandLineError
+
+    static var launchPath = "/usr/sbin/system_profiler"
+
+    static func listDeveloperTools() -> AnyPublisher<[DeveloperTool], SystemProfiler.Error> {
+        let publisher: AnyPublisher<SystemProfiler.DeveloperToolsList, SystemProfiler.Error> = SystemProfiler.executeJSON(.listDeveloperTools())
+        return publisher
+            .map { $0.list }
+            .eraseToAnyPublisher()
+    }
+}
+
+private extension SystemProfiler {
+
+    struct Command: CommandLineCommand {
+        let arguments: [String]
+
+        private init(_ subcommand: String, arguments: [String]) {
+            self.arguments = [subcommand] + arguments
+        }
+
+        /// List the available developer tools.
+        static func listDeveloperTools() -> Command {
+            Command("SPDeveloperToolsDataType", arguments: ["-json"])
+        }
+    }
+}
+
+struct DeveloperTool: Decodable, Equatable {
+    private enum CodingKeys: String, CodingKey {
+        case path = "spdevtools_path"
+        case version = "spdevtools_version"
+    }
+
+    static let empty = DeveloperTool(path: "", version: "")
+
+    let path: String
+    let version: String
+}
+
+// swiftlint:disable nesting
+extension SystemProfiler {
+
+    struct DeveloperToolsList: Decodable {
+        private enum CodingKeys: String, CodingKey {
+            case list = "SPDeveloperToolsDataType"
+        }
+
+        let list: [DeveloperTool]
+    }
+
+}
+// swiftlint:enable nesting

--- a/ControlRoom/Controllers/XcodeCommandLineToolsController.swift
+++ b/ControlRoom/Controllers/XcodeCommandLineToolsController.swift
@@ -16,7 +16,7 @@ struct XcodeCommandLineToolsController {
             .replaceError(with: ([], ""))
             .map { devTools, xcodeSelectResult -> DeveloperTool in
                 for devTool in devTools {
-                    if xcodeSelectResult.contains(devTool.path) {
+                    if xcodeSelectResult.contains(devTool.path), devTool.version >= "11.4" {
                         return devTool
                     }
                 }

--- a/ControlRoom/Helpers/CommandLineExecuter.swift
+++ b/ControlRoom/Helpers/CommandLineExecuter.swift
@@ -1,0 +1,115 @@
+//
+//  CommandLineExecuter.swift
+//  ControlRoom
+//
+//  Created by Mario Iannotta on 30/03/2020.
+//  Copyright © 2020 Paul Hudson. All rights reserved.
+//
+
+import Combine
+import Foundation
+
+/**
+ FYI: Using Swift 5.3 it's possible to abstract also the error with something like this
+ ```
+ protocol CommandLineErrorRepresentable: Error {
+     static var missingCommand: Self { get }
+     static var missingOutput: Self { get }
+     static func unknown(_ error: Error) -> Self
+ }
+
+ enum CommandLineCommandExecuterError: CommandLineErrorRepresentable
+    case missingCommand
+    case missingOutput
+    case unknownError(Error)
+ }
+
+ protocol CommandLineCommandExecuter {
+    ...
+    associatedtype CommandLineError: CommandLineErrorRepresentable = CommandLineCommandExecuterError
+    ...
+
+    static func execute(_ arguments: [String], completion: @escaping (Result<Data, CommandLineError>) -> Void) {
+        ....
+    }
+ }
+ ```
+ */
+enum CommandLineError: Error {
+    case missingCommand
+    case missingOutput
+    case unknown(Swift.Error)
+}
+
+protocol CommandLineCommand {
+    var arguments: [String] { get }
+}
+
+protocol CommandLineCommandExecuter {
+
+    associatedtype Command: CommandLineCommand
+
+    static var launchPath: String { get }
+
+}
+
+extension CommandLineCommandExecuter {
+
+    private static func execute(_ arguments: [String], completion: @escaping (Result<Data, CommandLineError>) -> Void) {
+        DispatchQueue.global(qos: .userInitiated).async {
+            if let data = Process.execute(launchPath, arguments: arguments) {
+                completion(.success(data))
+            } else {
+                completion(.failure(.missingCommand))
+            }
+        }
+    }
+
+    static func execute(_ arguments: [String]) -> PassthroughSubject<Data, CommandLineError> {
+        let publisher = PassthroughSubject<Data, CommandLineError>()
+        execute(arguments) { result in
+            switch result {
+            case .success(let data):
+                publisher.send(data)
+                publisher.send(completion: .finished)
+            case .failure(let error):
+                publisher.send(completion: .failure(error))
+            }
+        }
+        return publisher
+    }
+
+    static func executeSubject(_ command: Command) -> PassthroughSubject<Data, CommandLineError> {
+        execute(command.arguments)
+    }
+
+    static func execute(_ command: Command, completion: ((Result<Data, CommandLineError>) -> Void)? = nil) {
+        execute(command.arguments, completion: completion ?? { _ in })
+    }
+
+    static func executeJSON<T: Decodable>(_ command: Command) -> AnyPublisher<T, CommandLineError> {
+        executeAndDecode(command.arguments, decoder: JSONDecoder())
+    }
+
+    static func executePropertyList<T: Decodable>(_ command: Command) -> AnyPublisher<T, CommandLineError> {
+        executeAndDecode(command.arguments, decoder: PropertyListDecoder())
+    }
+
+    private static func executeAndDecode<Item, Decoder>(_ arguments: [String],
+                                                        decoder: Decoder) -> AnyPublisher<Item, CommandLineError> where Item: Decodable,
+                                                                                                                        Decoder: TopLevelDecoder,
+                                                                                                                        Decoder.Input == Data {
+        execute(arguments)
+            .decode(type: Item.self, decoder: decoder)
+            .mapError({ error -> CommandLineError in
+                if error is DecodingError {
+                    return .missingOutput
+                } else if let command = error as? CommandLineError {
+                    return command
+                } else {
+                    return .unknown(error)
+                }
+            })
+            .eraseToAnyPublisher()
+    }
+}

--- a/ControlRoom/Loading/LoadingFailedView.swift
+++ b/ControlRoom/Loading/LoadingFailedView.swift
@@ -10,13 +10,16 @@ import SwiftUI
 
 /// Shown when loading the simulator data from simctl has failed.
 struct LoadingFailedView: View {
+
+    let errorMessage: String
+
     var body: some View {
-        Text("Loading failed. This usually happens because the command /usr/bin/xcrun can't be found.")
+        Text(errorMessage)
     }
 }
 
 struct LoadingFailed_Previews: PreviewProvider {
     static var previews: some View {
-        LoadingFailedView()
+        LoadingFailedView(errorMessage: "Lorem ipsum")
     }
 }

--- a/ControlRoom/Main Window/MainView.swift
+++ b/ControlRoom/Main Window/MainView.swift
@@ -17,7 +17,9 @@ struct MainView: View {
     var body: some View {
         Group {
             if controller.loadingStatus == .failed {
-                LoadingFailedView()
+                LoadingFailedView(errorMessage: "Loading failed. This usually happens because the command /usr/bin/xcrun can't be found.")
+            } else if controller.loadingStatus == .invalidCommandLineTool {
+                LoadingFailedView(errorMessage: "Loading failed. You need to use Xcode 11.4+ and install the command line tools.")
             } else if controller.loadingStatus == .success {
                 SplitLayoutView(controller: controller)
             } else {

--- a/ControlRoom/Main Window/MainView.swift
+++ b/ControlRoom/Main Window/MainView.swift
@@ -16,12 +16,12 @@ struct MainView: View {
 
     var body: some View {
         Group {
-            if controller.loadingStatus == .loading {
-                LoadingView()
+            if controller.loadingStatus == .failed {
+                LoadingFailedView()
             } else if controller.loadingStatus == .success {
                 SplitLayoutView(controller: controller)
             } else {
-                LoadingFailedView()
+                LoadingView()
             }
         }
         .frame(minWidth: 500, maxWidth: .infinity, minHeight: 500, maxHeight: .infinity)


### PR DESCRIPTION
This PR fix #80 
A new protocol `CommandLineExecuter` has been introduced in order to reuse what has been done for `SimCtl` for other controllers that require IO from the command line.