### PR TITLE
Raise minimum window size

### DIFF
--- a/ControlRoom/Main Window/MainView.swift
+++ b/ControlRoom/Main Window/MainView.swift
@@ -27,7 +27,7 @@ struct MainView: View {
                 LoadingView()
             }
         }
-        .frame(minWidth: 500, maxWidth: .infinity, minHeight: 500, maxHeight: .infinity)
+        .frame(minWidth: 950, maxWidth: .infinity, minHeight: 600, maxHeight: .infinity)
         .sheet(item: $uiState.currentSheet, content: sheetView)
     }
 

--- a/ControlRoom/Main Window/MainWindowController.swift
+++ b/ControlRoom/Main Window/MainWindowController.swift
@@ -37,7 +37,7 @@ class MainWindowController: NSWindowController {
     override func loadWindow() {
         // Create the window and set the content view.
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 800, height: 300),
+            contentRect: NSRect(x: 0, y: 0, width: 950, height: 600),
             styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
             backing: .buffered, defer: false)
         window.setFrameAutosaveName("Main Window")


### PR DESCRIPTION
Very simple PR here. The default window size (and also the minimum) was too small for the layout to work correctly. This raises that to the point that allows for proper layout.

Notably, the tab bar was not functional at small window sizes due to content overflow vertically. This seems to be due to `Form` on macOS using a `VStack` under the hood without any intrinsic scrolling ability.

Great little app, cheers for putting this together :)