### PR TITLE
Added support for "xcrun simctl delete unavailable" as a menu bar item.

### DIFF
--- a/ControlRoom/Base.lproj/Main.storyboard
+++ b/ControlRoom/Base.lproj/Main.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="16097" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16096"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097"/>
     </dependencies>
     <scenes>
         <!--Application-->
@@ -65,6 +65,11 @@
                                         <menuItem title="New Simulator..." keyEquivalent="n" id="WUk-cr-sBl">
                                             <connections>
                                                 <action selector="newSimulator:" target="Ady-hI-5gd" id="QHt-ra-ClI"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Delete Unavailable Simulators..." keyEquivalent="D" id="tVk-RZ-EV2">
+                                            <connections>
+                                                <action selector="deleteUnavailable:" target="Ady-hI-5gd" id="nEs-s6-Ptr"/>
                                             </connections>
                                         </menuItem>
                                         <menuItem title="Close" keyEquivalent="w" id="DVo-aG-piG">

--- a/ControlRoom/Controllers/UIState.swift
+++ b/ControlRoom/Controllers/UIState.swift
@@ -17,8 +17,15 @@ class UIState: ObservableObject {
         var id: Int { rawValue }
     }
 
+    enum Alert: Int, Identifiable {
+        case confirmDeleteUnavailable
+
+        var id: Int { rawValue }
+    }
+
     static let shared = UIState()
     @Published var currentSheet: Sheet?
+    @Published var currentAlert: Alert?
 
     private init() { }
 }

--- a/ControlRoom/Main Window/MainView.swift
+++ b/ControlRoom/Main Window/MainView.swift
@@ -29,6 +29,7 @@ struct MainView: View {
         }
         .frame(minWidth: 500, maxWidth: .infinity, minHeight: 500, maxHeight: .infinity)
         .sheet(item: $uiState.currentSheet, content: sheetView)
+        .alert(item: $uiState.currentAlert, content: alert)
     }
 
     private func sheetView(for sheet: UIState.Sheet) -> some View {
@@ -42,6 +43,17 @@ struct MainView: View {
                 NotificationEditorView()
                     .environmentObject(preferences)
             }
+        }
+    }
+
+    private func alert(for alert: UIState.Alert) -> Alert {
+        if alert == .confirmDeleteUnavailable {
+            let confirmButton = Alert.Button.default(Text("Confirm")) {
+                SimCtl.execute(.delete(.unavailable))
+            }
+            return Alert(title: Text("Are you sure you want to delete all unavailable simulators?"), primaryButton: confirmButton, secondaryButton: .cancel())
+        } else {
+            return Alert(title: Text("Unknown Alert"))
         }
     }
 }

--- a/ControlRoom/Main Window/MainWindowController.swift
+++ b/ControlRoom/Main Window/MainWindowController.swift
@@ -73,6 +73,10 @@ class MainWindowController: NSWindowController {
         UIState.shared.currentSheet = .createSimulator
     }
 
+    @IBAction func deleteUnavailable(_ sender: Any) {
+        UIState.shared.currentAlert = .confirmDeleteUnavailable
+    }
+
 }
 
 extension MainWindowController: NSMenuItemValidation {


### PR DESCRIPTION
Hey Paul,

I was listening to your Podcast and heard you mention ControlRoom so I thought I would check it out.  I noticed there wasn't an option for deleting the unavailable simulators, so I thought I would try adding it.