### PR TITLE
Remove clipped SideBar-Icons

### DIFF
--- a/ControlRoom/Main Window/SimulatorSidebarView.swift
+++ b/ControlRoom/Main Window/SimulatorSidebarView.swift
@@ -79,7 +79,8 @@ struct SimulatorSidebarView: View {
             Image(nsImage: simulator.image)
                 .resizable()
                 .aspectRatio(1.0, contentMode: .fit)
-                .frame(maxWidth: 24)
+                .frame(maxWidth: 24, alignment: .center)
+                .padding(.top, 2)
             Text(simulator.name)
             Spacer()
         }


### PR DESCRIPTION
Improve the Sidebar and remove the clipped icons. 

https://github.com/twostraws/ControlRoom/issues/87

First Github PR. Hoply without mistakes :) 

