### PR TITLE
App view enhancements and fixes

### DIFF
--- a/ControlRoom/Controllers/Application.swift
+++ b/ControlRoom/Controllers/Application.swift
@@ -7,8 +7,9 @@
 //
 
 import Foundation
+import AppKit
 
-struct Application: Hashable {
+struct Application: Hashable, Comparable {
     let url: URL?
     let type: ApplicationType?
     let displayName: String
@@ -20,6 +21,10 @@ struct Application: Hashable {
     let bundleURL: URL?
 
     static let `default` = Application()
+
+	static func < (lhs: Application, rhs: Application) -> Bool {
+		lhs.displayName.localizedStandardCompare(rhs.displayName) == .orderedAscending
+	}
 
     private init() {
         url = nil
@@ -46,16 +51,57 @@ struct Application: Hashable {
         versionNumber = plistDictionary?["CFBundleShortVersionString"] as? String ?? ""
         buildNumber = plistDictionary?["CFBundleVersion"] as? String ?? ""
 
-        imageURLs = [Self.fetchIconNames(plistDitionary: plistDictionary),
-                     Self.fetchIconNames(plistDitionary: plistDictionary, platformIdentifier: "~ipad")]
-            .flatMap { $0 }
-            .compactMap { Bundle(url: url)?.urlForImageResource($0) }
+        imageURLs = Self.fetchIconName(plistDitionary: plistDictionary)
+			.sorted(by: >)
+			.compactMap { Bundle(url: url)?.urlForImageResource($0) }
 
         dataFolderURL = URL(string: application.dataFolderPath ?? "")
         bundleURL = URL(string: application.bundlePath)
     }
 
-    private static func fetchIconNames(plistDitionary: NSDictionary?, platformIdentifier: String = "") -> [String] {
+	var icon: NSImage? {
+		guard let imageURLs = imageURLs else { return nil }
+		for iconURL in imageURLs {
+			if let iconImage = NSImage(contentsOf: iconURL) {
+				return iconImage
+			}
+		}
+		return nil
+	}
+
+    private static func fetchIconName(plistDitionary: NSDictionary?) -> [String] {
+		guard let plistDitionary = plistDitionary else { return [] }
+
+		var iconFilesNames = iconsList(plistDitionary: plistDitionary)
+		if iconFilesNames.isEmpty {
+			iconFilesNames = iconsList(plistDitionary: plistDitionary, platformIdentifier: "~ipad")
+
+			//if empty, check for CFBundleIconFiles (since 3.2)
+			if iconFilesNames.isEmpty, let iconFiles = plistDitionary["CFBundleIconFiles"] as? [String] {
+				iconFilesNames = iconFiles
+			}
+		}
+
+		if !iconFilesNames.isEmpty {
+			//Search some patterns for primary app icon
+			for match in ["76", "60"] {
+				let result = iconFilesNames.filter { $0.contains(match) }
+				if !result.isEmpty {
+					return result
+				}
+			}
+
+			return iconFilesNames
+		}
+
+		//Check for CFBundleIconFile (legacy, before 3.2)
+		if let iconFileName = plistDitionary["CFBundleIconFile"] as? String {
+			return [iconFileName]
+		}
+		return []
+    }
+
+	private static func iconsList(plistDitionary: NSDictionary?, platformIdentifier: String = "") -> [String] {
         let scaleSuffixes: [String] = ["@2x", "@3x"]
         guard
             let plistDitionary = plistDitionary,

--- a/ControlRoom/Controllers/SimCtl+SubCommands.swift
+++ b/ControlRoom/Controllers/SimCtl+SubCommands.swift
@@ -446,7 +446,7 @@ extension SimCtl {
                     return ["poll"]
                 case .recordVideo(let codec, let display, let mask, let force, let url):
                     var arguments = [String]()
-                    
+
                     if let codec = codec {
                         arguments.append(contentsOf: codec.arguments)
                     }

--- a/ControlRoom/Controllers/SimulatorsController.swift
+++ b/ControlRoom/Controllers/SimulatorsController.swift
@@ -190,7 +190,7 @@ class SimulatorsController: ObservableObject {
             let selectedDeviceUDID = selectedSimulatorIDs.first
             else { return }
         SimCtl.listApplications(selectedDeviceUDID)
-            .catch { _ in Empty<SimCtl.ApplicationsList, Never>() }
+            .catch { _ in Just(SimCtl.ApplicationsList()) }
             .map { $0.values.compactMap(Application.init) }
             .receive(on: DispatchQueue.main)
             .assign(to: \.applications, on: self)


### PR DESCRIPTION
Enhancements and fixes to the App tab.
- The app picker order changed each time it was opened. Now it is sorted
- The app picker displayed only the app bundle ids. Now it displays the app icon and the app name too.
- Some app icons couldn't be found because CFBundleIconFiles was not checked. Some applications like Contacts still don't have an icon because it is in an encrypted file. In this case, a blank icon is displayed.
- The "Show system app" button is moved to the right so that it is no longer crushed when the window is resized.
- The icon is moved under the picker.
- App information wasn't updated when a system app was selected and the "Show system apps" was unchecked.
- Labels are added to the version and build number.
- The app list is now empty when a non-booted device is selected.
- The "Open data folder" is now disabled when the url is not available (Photos, Settings...)
- The "Uninstall app" is now disabled for system apps.