### PR TITLE
Moved some UserDefaults outside of Preferences to avoid unnecessary .body computations

### DIFF
--- a/ControlRoom.xcodeproj/xcshareddata/xcschemes/Debug - ControlRoom.xcscheme
+++ b/ControlRoom.xcodeproj/xcshareddata/xcschemes/Debug - ControlRoom.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "511BA57823F3FFEA00E3E660"
-               BuildableName = "ControlRoom.app"
+               BuildableName = "Control Room.app"
                BlueprintName = "ControlRoom"
                ReferencedContainer = "container:ControlRoom.xcodeproj">
             </BuildableReference>
@@ -55,7 +55,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "511BA57823F3FFEA00E3E660"
-            BuildableName = "ControlRoom.app"
+            BuildableName = "Control Room.app"
             BlueprintName = "ControlRoom"
             ReferencedContainer = "container:ControlRoom.xcodeproj">
          </BuildableReference>
@@ -72,7 +72,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "511BA57823F3FFEA00E3E660"
-            BuildableName = "ControlRoom.app"
+            BuildableName = "Control Room.app"
             BlueprintName = "ControlRoom"
             ReferencedContainer = "container:ControlRoom.xcodeproj">
          </BuildableReference>

--- a/ControlRoom.xcodeproj/xcshareddata/xcschemes/Release - ControlRoom.xcscheme
+++ b/ControlRoom.xcodeproj/xcshareddata/xcschemes/Release - ControlRoom.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "511BA57823F3FFEA00E3E660"
-               BuildableName = "ControlRoom.app"
+               BuildableName = "Control Room.app"
                BlueprintName = "ControlRoom"
                ReferencedContainer = "container:ControlRoom.xcodeproj">
             </BuildableReference>
@@ -56,7 +56,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "511BA57823F3FFEA00E3E660"
-            BuildableName = "ControlRoom.app"
+            BuildableName = "Control Room.app"
             BlueprintName = "ControlRoom"
             ReferencedContainer = "container:ControlRoom.xcodeproj">
          </BuildableReference>
@@ -73,7 +73,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "511BA57823F3FFEA00E3E660"
-            BuildableName = "ControlRoom.app"
+            BuildableName = "Control Room.app"
             BlueprintName = "ControlRoom"
             ReferencedContainer = "container:ControlRoom.xcodeproj">
          </BuildableReference>

--- a/ControlRoom/AppDelegate.swift
+++ b/ControlRoom/AppDelegate.swift
@@ -16,10 +16,25 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     var menuBarItem: NSStatusItem!
 
+    @AppStorage("CRWantsMenuBarIcon") private var wantsMenuBarIcon = true
+    @AppStorage("CRApps_LastOpenURL") private var lastOpenURL = ""
+    @AppStorage("CRApps_LastBundleID") private var lastBundleID = ""
+    @AppStorage("CRLastSimulatorUDID") private var lastSimulatorUDID = "booted"
+    @AppStorage("CRApps_PushPayload") private var pushPayload = """
+    {
+        "aps": {
+            "alert": {
+                "body": "Hello, World!",
+                "title": "From Control Room"
+            }
+        }
+    }
+    """
+
     func applicationDidFinishLaunching(_ aNotification: Notification) {
         mainWindow.showWindow(self)
 
-        if mainWindow.preferences.wantsMenuBarIcon {
+        if wantsMenuBarIcon {
             addMenuBarItem()
         }
 
@@ -82,14 +97,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @objc func resendLastPushNotification() {
-        SimCtl.sendPushNotification(mainWindow.preferences.lastSimulatorUDID, appID: mainWindow.preferences.lastBundleID, jsonPayload: mainWindow.preferences.pushPayload)
+        SimCtl.sendPushNotification(lastSimulatorUDID, appID: lastBundleID, jsonPayload: pushPayload)
     }
 
     @objc func restartLastSelectedApp() {
-        SimCtl.restart(mainWindow.preferences.lastSimulatorUDID, appID: mainWindow.preferences.lastBundleID)
+        SimCtl.restart(lastSimulatorUDID, appID: lastBundleID)
     }
 
     @objc func reopenLastURL() {
-        SimCtl.openURL(mainWindow.preferences.lastSimulatorUDID, URL: mainWindow.preferences.lastOpenURL)
+        SimCtl.openURL(lastSimulatorUDID, URL: lastOpenURL)
     }
 }

--- a/ControlRoom/Controllers/Preferences.swift
+++ b/ControlRoom/Controllers/Preferences.swift
@@ -10,7 +10,7 @@ import Combine
 import KeyboardShortcuts
 import SwiftUI
 
-class Preferences: ObservableObject {
+final class Preferences: ObservableObject {
     /// For parts of the app that want to observe a particular value directly,
     /// they need a way to be notified AFTER the value has changed.
     let objectDidChange = PassthroughSubject<Void, Never>()
@@ -19,29 +19,10 @@ class Preferences: ObservableObject {
 
     @UserDefault("CRWantsMenuBarIcon") var wantsMenuBarIcon = true
     @UserDefault("CRWantsFloatingWindow") var wantsFloatingWindow = false
-    @UserDefault("CRLastSimulatorUDID") var lastSimulatorUDID = "booted"
 
     @UserDefault("CRSidebar_ShowDefaultSimulator") var showDefaultSimulator = true
     @UserDefault("CRSidebar_ShowBootedDevicesFirst") var showBootedDevicesFirst = false
     @UserDefault("CRSidebar_ShowOnlyActiveDevices") var shouldShowOnlyActiveDevices = false
-    @UserDefault("CRSidebar_FilterText") var filterText = ""
-
-    @UserDefault("CRApps_LastOpenURL") var lastOpenURL = ""
-    @UserDefault("CRApps_LastBundleID") var lastBundleID = ""
-    @UserDefault("CRApps_ShowSystemApps") var shouldShowSystemApps = true
-    @UserDefault("CRApps_PushPayload") var pushPayload = """
-    {
-        "aps": {
-            "alert": {
-                "body": "Hello, World!",
-                "title": "From Control Room"
-            }
-        }
-    }
-    """
-
-    @UserDefault("CRNetwork_CarrierName") var carrierName = "Carrier"
-    @UserDefault("CRMedia_VideoFormat") var videoFormat = 0
 
     init(defaults: UserDefaults = .standard) {
         userDefaults = defaults

--- a/ControlRoom/Controllers/SimulatorsController.swift
+++ b/ControlRoom/Controllers/SimulatorsController.swift
@@ -42,6 +42,8 @@ class SimulatorsController: ObservableObject {
     private(set) var deviceTypes = [DeviceType]()
     private(set) var runtimes = [Runtime]()
 
+    @AppStorage("CRSidebar_FilterText") private var filterText = ""
+
     /// The simulators the user has selected to work with. If this has one item then
     /// they are working with a simulator; if more than one they are probably about
     /// to delete several at a time.
@@ -151,10 +153,10 @@ class SimulatorsController: ObservableObject {
     }
 
     /// Filters the list of simulators using `filterText`, and assigns the result to `simulators`.
-    private func filterSimulators() {
+    func filterSimulators() {
         guard loadingStatus == .success else { return }
 
-        let trimmed = preferences.filterText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmed = filterText.trimmingCharacters(in: .whitespacesAndNewlines)
         var filtered = allSimulators
 
         if preferences.showBootedDevicesFirst {

--- a/ControlRoom/Main Window/MainView.swift
+++ b/ControlRoom/Main Window/MainView.swift
@@ -11,7 +11,6 @@ import SwiftUI
 /// Hosts a LoadingView followed by the main ControlView, or a LoadingFailedView if simctl failed.
 struct MainView: View {
     @ObservedObject var controller: SimulatorsController
-    @EnvironmentObject var preferences: Preferences
     @EnvironmentObject var uiState: UIState
 
     var body: some View {
@@ -36,12 +35,10 @@ struct MainView: View {
         Group {
             if sheet == .preferences {
                 PreferencesView()
-                    .environmentObject(preferences)
             } else if sheet == .createSimulator {
                 CreateSimulatorActionSheet(controller: controller)
             } else if sheet == .notificationEditor {
                 NotificationEditorView()
-                    .environmentObject(preferences)
             }
         }
     }

--- a/ControlRoom/Main Window/SidebarView.swift
+++ b/ControlRoom/Main Window/SidebarView.swift
@@ -13,6 +13,9 @@ struct SidebarView: View {
     @EnvironmentObject var preferences: Preferences
     @ObservedObject var controller: SimulatorsController
 
+    @AppStorage("CRSidebar_FilterText") private var filterText = ""
+    @AppStorage("CRLastSimulatorUDID") private var lastSimulatorUDID = "booted"
+
     @State private var shouldShowDeleteAlert = false
 
     private var selectedSimulatorsSummary: String {
@@ -61,7 +64,7 @@ struct SidebarView: View {
                 .buttonStyle(BorderlessButtonStyle())
                 .padding(.leading, 3)
 
-                FilterField("Filter", text: $preferences.filterText)
+                FilterField("Filter", text: $filterText.onChange(controller.filterSimulators))
             }
             .padding(2)
             .sheet(isPresented: $shouldShowDeleteAlert) {
@@ -106,7 +109,7 @@ struct SidebarView: View {
         // If we selected exactly one simulator, stash its UDID away so we can
         // quickly use it elsewhere in the app, e.g. in the menu bar icon.
         if controller.selectedSimulatorIDs.count == 1 {
-            preferences.lastSimulatorUDID = controller.selectedSimulators.first!.udid
+            lastSimulatorUDID = controller.selectedSimulators.first!.udid
         }
     }
 }

--- a/ControlRoom/Simulator UI/ControlScreens/AppView/NotificationEditorView.swift
+++ b/ControlRoom/Simulator UI/ControlScreens/AppView/NotificationEditorView.swift
@@ -10,9 +10,21 @@ import SwiftUI
 
 struct NotificationEditorView: View {
     @EnvironmentObject var preferences: Preferences
+
     @State private var notificationAps = PushNotificationAPS()
     @State private var userInfo = ""
     @State private var shouldDismissConfirmationAlert: Bool = false
+
+    @AppStorage("CRApps_PushPayload") private var pushPayload = """
+    {
+        "aps": {
+            "alert": {
+                "body": "Hello, World!",
+                "title": "From Control Room"
+            }
+        }
+    }
+    """
 
     private var fullJson: String {
         guard
@@ -67,7 +79,7 @@ struct NotificationEditorView: View {
         }
         .padding(20)
         .onAppear {
-            notificationAps = preferences.pushPayload
+            notificationAps = pushPayload
                 .data(using: .utf8)
                 .flatMap { try? JSONDecoder().decode(PushNotification.self, from: $0) }?.aps ?? PushNotificationAPS()
             }
@@ -75,12 +87,12 @@ struct NotificationEditorView: View {
     }
 
     private func saveNotificationJson() {
-        preferences.pushPayload = fullJson
+        pushPayload = fullJson
         dismiss()
     }
 
     private func discardNotificationJson() {
-        if preferences.pushPayload != fullJson {
+        if pushPayload != fullJson {
             shouldDismissConfirmationAlert = true
         } else {
             dismiss()

--- a/ControlRoom/Simulator UI/ControlScreens/NetworkView.swift
+++ b/ControlRoom/Simulator UI/ControlScreens/NetworkView.swift
@@ -10,7 +10,6 @@ import SwiftUI
 
 /// Controls WiFi and cellular data state for the whole device.
 struct NetworkView: View {
-    @EnvironmentObject var preferences: Preferences
     let simulator: Simulator
 
     /// The active data network; can be one of "WiFi", "3G", "4G", "LTE", "LTE-A", or "LTE+".
@@ -28,10 +27,12 @@ struct NetworkView: View {
     /// How many cellular bars the device is showing, as a range from 0 through 4.
     @State private var cellularBar: SimCtl.StatusBar.CellularBars = .four
 
+    @AppStorage("CRNetwork_CarrierName") private var carrierName = "Carrier"
+
     var body: some View {
         Form {
             Section {
-                TextField("Operator", text: $preferences.carrierName, onCommit: updateData)
+                TextField("Operator", text: $carrierName, onCommit: updateData)
 
                 Picker("Network type:", selection: $dataNetwork.onChange(updateData)) {
                     ForEach(SimCtl.StatusBar.DataNetwork.allCases, id: \.self) { network in
@@ -92,7 +93,7 @@ struct NetworkView: View {
         SimCtl.overrideStatusBarNetwork(simulator.udid, network: dataNetwork,
                                         wifiMode: wiFiMode, wifiBars: wiFiBar,
                                         cellMode: cellularMode, cellBars: cellularBar,
-                                        carrier: preferences.carrierName)
+                                        carrier: carrierName)
     }
 
     /// Workaround for getting configurable image sizes in Segmented Control; It seems to be broken in SwiftUI right now.

--- a/ControlRoom/Simulator UI/ControlScreens/ScreenView.swift
+++ b/ControlRoom/Simulator UI/ControlScreens/ScreenView.swift
@@ -33,7 +33,6 @@ struct ScreenView: View {
         var mask: SimCtl.IO.Mask?
     }
 
-    @EnvironmentObject var preferences: Preferences
     let simulator: Simulator
 
     /// The user's settings for a screenshot.
@@ -47,6 +46,8 @@ struct ScreenView: View {
 
     /// Converting MP4 to GIF takes time, so this tracks the progress of the operation
     @State private var exportProgress: CGFloat = 1.0
+
+    @AppStorage("CRMedia_VideoFormat") private var videoFormat = 0
 
     var body: some View {
         Form {
@@ -63,13 +64,13 @@ struct ScreenView: View {
             }
 
             Section(header: Text("Video").font(.headline)) {
-                Picker("Format:", selection: $preferences.videoFormat) {
+                Picker("Format:", selection: $videoFormat) {
                     ForEach(0..<VideoFormat.all.count) { item in
                         Text(VideoFormat.all[item].name)
                     }
                 }
 
-                Text(VideoFormat.all[preferences.videoFormat].description)
+                Text(VideoFormat.all[videoFormat].description)
 
                 HStack {
                     Button(recordingProcess == nil ? "Start Recording" : "Stop Recording", action: toggleRecordingVideo)
@@ -145,7 +146,7 @@ struct ScreenView: View {
         let paths = FileManager.default.urls(for: .desktopDirectory, in: .userDomainMask)
         let savePath = paths[0].appendingPathComponent(recordingFilename).path
 
-        let format = VideoFormat.all[preferences.videoFormat].name
+        let format = VideoFormat.all[videoFormat].name
 
         if format.hasPrefix("GIF") {
             var size: CGFloat?

--- a/ControlRoom/Simulator UI/ControlScreens/SystemView.swift
+++ b/ControlRoom/Simulator UI/ControlScreens/SystemView.swift
@@ -11,8 +11,11 @@ import SwiftUI
 
 /// Controls system-wide settings such as time and appearance.
 struct SystemView: View {
-    @EnvironmentObject var preferences: Preferences
     let simulator: Simulator
+
+    @EnvironmentObject var preferences: Preferences
+
+    @AppStorage("CRApps_LastOpenURL") private var lastOpenURL = ""
 
     /// The current time to show in the device.
     @State private var time = Date()
@@ -100,7 +103,7 @@ struct SystemView: View {
             Group {
                 Section(header: Text("Open URL")) {
                     HStack {
-                        TextField("URL / deep link to open", text: $preferences.lastOpenURL)
+                        TextField("URL / deep link to open", text: $lastOpenURL)
                         Button("Open URL", action: openURL)
                     }
                 }
@@ -168,7 +171,7 @@ struct SystemView: View {
 
     /// Opens a URL in the appropriate device app.
     func openURL() {
-        SimCtl.openURL(simulator.udid, URL: preferences.lastOpenURL)
+        SimCtl.openURL(simulator.udid, URL: lastOpenURL)
     }
 
     /// Erases the current device.


### PR DESCRIPTION
Discussion in issue https://github.com/twostraws/ControlRoom/issues/107.

I moved some `UserDefaults` outside of `Preferences` class because they should be local state of some views instead of global shared state (e.g. `filterText`, `carrier`). I used `@AppStorage` for memory persistence accros launches.

For `filterText` I made the `filterSimulator()` func of `SimulatorsController` public to be able to update the list when `filterText` changes.

I also removed some useless `.environmentObject(preferences)` calls since it was already called higher in the view tree.

There are still some `UserDefaults` that could be removed from `Preferences` I think.

All those changes avoid lots of `.body` computations that were uselessly triggered by the many `Preferences` updates triggered by keystrokes (in URL and Carrier fields for instance) and updating the simulators list view.