### PR TITLE
Correct module name.

### DIFF
--- a/ControlRoom.xcodeproj/project.pbxproj
+++ b/ControlRoom.xcodeproj/project.pbxproj
@@ -824,7 +824,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.hackingwithswift.ControlRoomTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ControlRoom.app/Contents/MacOS/ControlRoom";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Control Room.app/Contents/MacOS/Control Room";
 			};
 			name = Debug;
 		};
@@ -845,7 +845,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.hackingwithswift.ControlRoomTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ControlRoom.app/Contents/MacOS/ControlRoom";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Control Room.app/Contents/MacOS/Control Room";
 			};
 			name = Release;
 		};

--- a/ControlRoomTests/Controllers/SimCtl+SubCommandsTests.swift
+++ b/ControlRoomTests/Controllers/SimCtl+SubCommandsTests.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2020 Paul Hudson. All rights reserved.
 //
 
-@testable import ControlRoom
+@testable import Control_Room
 import XCTest
 
 class SimCtlSubCommandsTests: XCTestCase {


### PR DESCRIPTION
As mentioned in issue #115 this is due to an oversight in pull request #112 my apologies.