### PR TITLE
Add a button to open the first app group folder

### DIFF
--- a/ControlRoom/Controllers/Application.swift
+++ b/ControlRoom/Controllers/Application.swift
@@ -18,6 +18,7 @@ struct Application: Hashable, Comparable {
     let buildNumber: String
     let imageURLs: [URL]?
     let dataFolderURL: URL?
+    let firstAppGroupFolderURL: URL?
     let bundleURL: URL?
 
     static let `default` = Application()
@@ -35,6 +36,7 @@ struct Application: Hashable, Comparable {
         buildNumber = ""
         imageURLs = nil
         dataFolderURL = nil
+        firstAppGroupFolderURL = nil
         bundleURL = nil
     }
 
@@ -56,6 +58,7 @@ struct Application: Hashable, Comparable {
 			.compactMap { Bundle(url: url)?.urlForImageResource($0) }
 
         dataFolderURL = URL(string: application.dataFolderPath ?? "")
+        firstAppGroupFolderURL = URL(string: application.appGroupsFolderPaths?.first?.value ?? "")
         bundleURL = URL(string: application.bundlePath)
     }
 

--- a/ControlRoom/Controllers/SimCtl+Types.swift
+++ b/ControlRoom/Controllers/SimCtl+Types.swift
@@ -144,6 +144,7 @@ extension SimCtl {
         let displayName: String
         let bundlePath: String
         let dataFolderPath: String?
+        let appGroupsFolderPaths: [String: String]?
     }
 }
 
@@ -155,5 +156,6 @@ extension SimCtl.Application {
         case displayName = "CFBundleDisplayName"
         case bundlePath = "Bundle"
         case dataFolderPath = "DataContainer"
+        case appGroupsFolderPaths = "GroupContainers"
     }
 }

--- a/ControlRoom/Simulator UI/ControlScreens/AppView/AppView.swift
+++ b/ControlRoom/Simulator UI/ControlScreens/AppView/AppView.swift
@@ -78,6 +78,8 @@ struct AppView: View {
                         Menu {
                             Button("Open data folder", action: openDataFolder)
                                 .disabled(selectedApplication.dataFolderURL == nil)
+                            Button("Open first app group folder", action: openFirstAppGroupFolder)
+                                .disabled(selectedApplication.firstAppGroupFolderURL == nil)
                             Button("Open app bundle", action: openAppBundle)
                                 .disabled(selectedApplication.bundleURL == nil)
 
@@ -163,6 +165,12 @@ struct AppView: View {
     func openDataFolder() {
         guard let dataFolderURL = selectedApplication.dataFolderURL else { return }
         NSWorkspace.shared.activateFileViewerSelecting([dataFolderURL])
+    }
+
+    /// Reveals the first app group's container directory in Finder.
+    func openFirstAppGroupFolder() {
+        guard let firstAppGroupFolderURL = selectedApplication.firstAppGroupFolderURL else { return }
+        NSWorkspace.shared.activateFileViewerSelecting([firstAppGroupFolderURL])
     }
 
     /// Reveals the app's bundle directory in Finder.


### PR DESCRIPTION
"Open first app group folder" open the first app group folder of the selected application.

![Screenshot 2021-02-24 at 13 32 26](https://user-images.githubusercontent.com/2878688/109003105-51dd3680-76a7-11eb-8caa-2425a6cf8dcd.png)

Output of `xcrun simctl listapps <device_id>`:

```
"bundle_id" = {
   [...]
   DataContainer = "file:///Users/xxxx/Library/Developer/CoreSimulator/Devices/4ED1E16E-52A3-4A6F-BFE4-6329C60D2840/data/Containers/Data/Application/2C05DC3C-48B8-44FB-9E22-BE3A5BDF9FF3/";
   GroupContainers = {
      "group_id" = "file:///Users/xxxx/Library/Developer/CoreSimulator/Devices/4ED1E16E-52A3-4A6F-BFE4-6329C60D2840/data/Containers/Shared/AppGroup/4FC3F1B2-76B4-44A4-80F8-92E65B48A41B/";
   };
   [...]
};
```

Feature requested here: https://github.com/twostraws/ControlRoom/issues/83