### PR TITLE
Add ffmpeg compression option for recorded videos

### DIFF
--- a/ControlRoom.xcodeproj/project.pbxproj
+++ b/ControlRoom.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		41C44ACD2616FCB50016B1E4 /* FFMPEGConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41C44ACC2616FCB50016B1E4 /* FFMPEGConverter.swift */; };
 		510871F225C317830009E39F /* SimulatorAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510871F125C317830009E39F /* SimulatorAction.swift */; };
 		5108721525C331360009E39F /* TextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5108721425C331360009E39F /* TextView.swift */; };
 		511BA57D23F3FFEA00E3E660 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511BA57C23F3FFEA00E3E660 /* AppDelegate.swift */; };
@@ -79,6 +80,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		41C44ACC2616FCB50016B1E4 /* FFMPEGConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FFMPEGConverter.swift; sourceTree = "<group>"; };
 		510871F125C317830009E39F /* SimulatorAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulatorAction.swift; sourceTree = "<group>"; };
 		5108721425C331360009E39F /* TextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextView.swift; sourceTree = "<group>"; };
 		511BA57923F3FFEA00E3E660 /* Control Room.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Control Room.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -259,6 +261,7 @@
 				555A145B23F70CCF00313BC5 /* Process.swift */,
 				5534157F23FE0514005C0A41 /* RecessedButtonStyle.swift */,
 				551F8CF623F4BEAC0006D1BD /* TypeIdentifier.swift */,
+				41C44ACC2616FCB50016B1E4 /* FFMPEGConverter.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -573,6 +576,7 @@
 				551F8CF123F498C30006D1BD /* SimulatorsController.swift in Sources */,
 				511BA5A623F420AB00E3E660 /* FormSpacer.swift in Sources */,
 				ACCD798C240ADEE20004ECE5 /* NotificationEditorView.swift in Sources */,
+				41C44ACD2616FCB50016B1E4 /* FFMPEGConverter.swift in Sources */,
 				70BE435A23F54B7200FD6282 /* LocationView.swift in Sources */,
 				ACD2064D2431F20000F8659B /* CommandLineExecuter.swift in Sources */,
 				5179289A25C37D2A000F6F3A /* KeyboardShortcuts.swift in Sources */,

--- a/ControlRoom/Helpers/FFMPEGConverter.swift
+++ b/ControlRoom/Helpers/FFMPEGConverter.swift
@@ -38,14 +38,27 @@ enum FFMPEGConverter: CommandLineCommandExecuter {
 
     static func convert(input inPath: String, output outPath: String,
                         callback: @escaping (Result<Void, CommandLineError>) -> Void) {
+        let initialSize = fileSizeString(inPath)
         execute(Command(inPath: inPath, outPath: outPath)) { result in
             switch result {
             case .success:
+                let resultSize = fileSizeString(outPath)
+                print("Video Compressed: \(initialSize) -> \(resultSize)")
                 callback(.success(()))
             case .failure(let error):
                 callback(.failure(error))
             }
         }
+    }
+
+    static private func fileSizeString(_ path: String) -> String {
+        guard let sizeAttribute = try? FileManager.default.attributesOfItem(atPath: path)[FileAttributeKey.size],
+              let size = sizeAttribute as? UInt64
+        else {
+            return "?"
+        }
+        let sizeMb = Double(size) / 1024 / 1024
+        return String(format: "%0.3f Mb", sizeMb)
     }
 }
 

--- a/ControlRoom/Helpers/FFMPEGConverter.swift
+++ b/ControlRoom/Helpers/FFMPEGConverter.swift
@@ -1,0 +1,87 @@
+//
+//  FFMPEGConverter.swift
+//  ControlRoom
+//
+//  Created by Nikolay Volosatov on 2.04.21.
+//  Copyright © 2021 Paul Hudson. All rights reserved.
+//
+
+import Foundation
+
+enum FFMPEGConverter: CommandLineCommandExecuter {
+    static var launchPath = "/usr/local/bin/ffmpeg"
+
+    struct Command: CommandLineCommand {
+        var inPath: String
+        var outPath: String
+
+        var fps = 60
+        var videoQuality = VideoQuality.default
+        var videoBitrate = "2.0M"
+        var audioBitrate = "128k"
+
+        var arguments: [String] {
+            [
+                "-i", inPath,
+                "-codec:v", "libx264",
+                "-b:v", videoBitrate,
+                "-filter:v", "fps=\(fps)",
+                "-crf", "\(videoQuality.crf)",
+                "-bf", "2",
+                "-flags", "+cgop",
+                "-pix_fmt", "yuv420p",
+                "-codec:a", "mp3",
+                "-strict",
+                "-2",
+                "-b:a", audioBitrate,
+                "-r:a", "48000",
+                "-movflags", "faststart",
+                outPath
+            ]
+        }
+    }
+
+    static let available: Bool = {
+        FileManager.default.fileExists(atPath: launchPath)
+    }()
+
+    static func convert(input inPath: String, output outPath: String,
+                        callback: @escaping (Result<Void, CommandLineError>) -> Void) {
+        execute(Command(inPath: inPath, outPath: outPath)) { result in
+            switch result {
+            case .success:
+                callback(.success(()))
+            case .failure(let error):
+                callback(.failure(error))
+            }
+        }
+    }
+}
+
+extension FFMPEGConverter {
+    enum VideoQuality {
+        case loseless
+        case high
+        case `default`
+        case low
+        case worstPossible
+        case custom(Int)
+
+        var crf: Int {
+            switch self {
+            case .loseless:
+                return 0
+            case .high:
+                return 18
+            case .default:
+                return 23
+            case .low:
+                return 28
+            case .worstPossible:
+                return 51
+            case .custom(let val):
+                return val
+            }
+        }
+    }
+}

--- a/ControlRoom/Helpers/FFMPEGConverter.swift
+++ b/ControlRoom/Helpers/FFMPEGConverter.swift
@@ -18,25 +18,16 @@ enum FFMPEGConverter: CommandLineCommandExecuter {
         var fps = 60
         var videoQuality = VideoQuality.default
         var videoBitrate = "2.0M"
-        var audioBitrate = "128k"
 
         var arguments: [String] {
             [
-                "-i", inPath,
-                "-codec:v", "libx264",
-                "-b:v", videoBitrate,
-                "-filter:v", "fps=\(fps)",
-                "-crf", "\(videoQuality.crf)",
-                "-bf", "2",
-                "-flags", "+cgop",
-                "-pix_fmt", "yuv420p",
-                "-codec:a", "mp3",
-                "-strict",
-                "-2",
-                "-b:a", audioBitrate,
-                "-r:a", "48000",
-                "-movflags", "faststart",
-                outPath
+                "-i", inPath,                   // Input file
+                "-codec:v", "libx264",          // Video Codec: H.264
+                "-b:v", videoBitrate,           // Limit video bitrate
+                "-filter:v", "fps=\(fps)",      // Set video FPS
+                "-crf", "\(videoQuality.crf)",  // Set H.264 compression quality (0 - 51, smaller better)
+                "-c:a", "copy",                 // Copy audio as is
+                outPath                         // Output file
             ]
         }
     }


### PR DESCRIPTION
Simctl records relatively large video files that can be easily compressed. From my experience: the video file can be 10 times smaller without significant loss in quality.

I'm not an expert in `ffmpeg` and not sure if such compression can be done using AVFoundation.
If you think that external implicit dependency on `ffmpeg` isn't a good idea I can investigate if AVFoundation can do the same compression itself(and I expect it should). Anyway, I'm open to discussion.