### PR TITLE
Use preferences to set terminal app path

### DIFF
--- a/ControlRoom/Controllers/Preferences.swift
+++ b/ControlRoom/Controllers/Preferences.swift
@@ -23,7 +23,7 @@ final class Preferences: ObservableObject {
     @UserDefault("CRSidebar_ShowDefaultSimulator") var showDefaultSimulator = true
     @UserDefault("CRSidebar_ShowBootedDevicesFirst") var showBootedDevicesFirst = false
     @UserDefault("CRSidebar_ShowOnlyActiveDevices") var shouldShowOnlyActiveDevices = false
-    
+
     @UserDefault("CRTerminalAppPath") var terminalAppPath = "/System/Applications/Utilities/Terminal.app"
 
     init(defaults: UserDefaults = .standard) {

--- a/ControlRoom/Controllers/Preferences.swift
+++ b/ControlRoom/Controllers/Preferences.swift
@@ -23,6 +23,8 @@ final class Preferences: ObservableObject {
     @UserDefault("CRSidebar_ShowDefaultSimulator") var showDefaultSimulator = true
     @UserDefault("CRSidebar_ShowBootedDevicesFirst") var showBootedDevicesFirst = false
     @UserDefault("CRSidebar_ShowOnlyActiveDevices") var shouldShowOnlyActiveDevices = false
+    
+    @UserDefault("CRTerminalAppPath") var terminalAppPath = "/System/Applications/Utilities/Terminal.app"
 
     init(defaults: UserDefaults = .standard) {
         userDefaults = defaults

--- a/ControlRoom/Preferences UI/PreferencesView.swift
+++ b/ControlRoom/Preferences UI/PreferencesView.swift
@@ -47,10 +47,10 @@ struct PreferencesView: View {
                     KeyboardShortcuts.Recorder(for: .reopenLastURL)
                 }
             }
-          
+
             Spacer()
                 .frame(height: 30)
-            
+
             Section(header: Text("Terminal app path").font(.headline)) {
                 TextField(
                     "Filepath",

--- a/ControlRoom/Preferences UI/PreferencesView.swift
+++ b/ControlRoom/Preferences UI/PreferencesView.swift
@@ -47,6 +47,18 @@ struct PreferencesView: View {
                     KeyboardShortcuts.Recorder(for: .reopenLastURL)
                 }
             }
+          
+            Spacer()
+                .frame(height: 30)
+            
+            Section(header: Text("Terminal app path").font(.headline)) {
+                TextField(
+                    "Filepath",
+                    text: $preferences.terminalAppPath
+                )
+                    .labelsHidden()
+                .textFieldStyle(.roundedBorder)
+            }
 
             Spacer()
                 .frame(height: 30)

--- a/ControlRoom/Simulator UI/ControlScreens/SystemView.swift
+++ b/ControlRoom/Simulator UI/ControlScreens/SystemView.swift
@@ -258,7 +258,9 @@ struct SystemView: View {
 	}
 
 	func openInTerminal(_ filePath: Simulator.FilePathKind) {
-		let terminalUrl = URL(fileURLWithPath: "/System/Applications/Utilities/Terminal.app") as CFURL
+        guard preferences.terminalAppPath.isNotEmpty else { return }
+        
+        let terminalUrl = URL(fileURLWithPath: preferences.terminalAppPath) as CFURL
 		let unmanagedTerminalUrl = Unmanaged<CFURL>.passUnretained(terminalUrl)
 
 		let folderUrl = simulator.urlForFilePath(filePath)

--- a/ControlRoom/Simulator UI/ControlScreens/SystemView.swift
+++ b/ControlRoom/Simulator UI/ControlScreens/SystemView.swift
@@ -259,7 +259,7 @@ struct SystemView: View {
 
 	func openInTerminal(_ filePath: Simulator.FilePathKind) {
         guard preferences.terminalAppPath.isNotEmpty else { return }
-        
+
         let terminalUrl = URL(fileURLWithPath: preferences.terminalAppPath) as CFURL
 		let unmanagedTerminalUrl = Unmanaged<CFURL>.passUnretained(terminalUrl)
 


### PR DESCRIPTION
Hi!,

I noticed that the file path to the Terminal app for opening in Terminal is hard coded to the Terminal.app.

I suggest maybe allowing users to specify the path to the app of their choosing. I for one use iTerm2 and would very much like to be given the option to use the same here as well.

This PR will add  the path to the preferences and use the UserDefaults to store whatever the user specifies so it can be used for the "Open in Terminal" feature.

<img width="364" alt="Skjermbilde 2022-01-04 kl  14 14 36" src="https://user-images.githubusercontent.com/1150153/148065114-6e9c8ca8-7413-483e-9d4b-0a361a0b6079.png">

I have run the tests and also made sure SwiftLint is happy :)
