### PR TITLE
Show and sort by OS version for simulators in sidebar

### DIFF
--- a/ControlRoom/Controllers/Simulator.swift
+++ b/ControlRoom/Controllers/Simulator.swift
@@ -175,9 +175,14 @@ struct Simulator: Identifiable, Comparable, Hashable {
 		}
 	}
 
-    /// Sort simulators alphabetically.
+    /// Sort simulators alphabetically, and then by OS version.
     static func < (lhs: Simulator, rhs: Simulator) -> Bool {
-        lhs.name < rhs.name
+        if lhs.name == rhs.name,
+           let lhsRuntime = lhs.runtime,
+           let rhsRuntime = rhs.runtime {
+            return lhsRuntime.buildversion < rhsRuntime.buildversion
+        }
+        return lhs.name < rhs.name
     }
 
     /// An example simulator for Xcode preview purposes

--- a/ControlRoom/Main Window/SimulatorSidebarView.swift
+++ b/ControlRoom/Main Window/SimulatorSidebarView.swift
@@ -23,9 +23,9 @@ struct SimulatorSidebarView: View {
     }
 
     private var simulatorSummary: String {
-        [simulator.name, simulator.runtime?.name]
+        [simulator.name, (simulator.runtime?.version).map { "(\($0))" }]
             .compactMap { $0 }
-            .joined(separator: " - ")
+            .joined(separator: " ")
     }
 
     private var statusImage: NSImage {
@@ -54,7 +54,7 @@ struct SimulatorSidebarView: View {
                 .frame(maxWidth: 24, alignment: .center)
                 .padding(.top, 2)
                 .shadow(color: .primary, radius: 1)
-            Text(simulator.name)
+            Text(simulatorSummary)
             Spacer()
         }
         .contextMenu(


### PR DESCRIPTION
Update the simulator listing to show the OS version, styled to match the simulator listing in Xcode, and sort by the version when the names match.
I updated the `simulatorSummary` var in SimulatorSidebarView, which appeared to otherwise be unused.

I used this to identify excess simulators I didn't want to keep, it was very helpful in cleaning up old sims.
Thanks for such a useful tool!

Before:
<img width="322" alt="Screen Shot 2022-02-02 at 8 25 46 PM" src="https://user-images.githubusercontent.com/35043/152281354-67a76bac-247a-4381-a2ef-09ff4fc0c36c.png">

After:
<img width="348" alt="Screen Shot 2022-02-02 at 8 25 10 PM" src="https://user-images.githubusercontent.com/35043/152281393-b00846ed-47ff-4232-8780-d4f82783d3e2.png">