### PR TITLE
Add support for jittering locations

### DIFF
--- a/ControlRoom/Simulator UI/ControlScreens/LocationView.swift
+++ b/ControlRoom/Simulator UI/ControlScreens/LocationView.swift
@@ -37,7 +37,8 @@ struct LocationView: View {
 
     /// User-facing text describing `currentLocation`
     var locationText: String {
-        String(format: "%.5f, %.5f", currentLocation.center.latitude, currentLocation.center.longitude)
+        let location = jitteredLocation ?? currentLocation.center
+        return String(format: "%.5f, %.5f", location.latitude, location.longitude)
     }
 
     var body: some View {


### PR DESCRIPTION
### Use case
In map and navigation-based applications, it can be useful to simulate the slight variations in locations you might see while using a device. 

### Solution
This PR adds a "jitter location" feature that, when enabled, will randomly generate a location slightly offset from the `currentLocation` selected on the map to simulate this behavior.

https://user-images.githubusercontent.com/2067455/166856190-58a8a74f-5832-47e9-b135-a8951087556e.mov


