### PR TITLE
Fix map view size

### DIFF
--- a/ControlRoom/Simulator UI/ControlScreens/LocationView.swift
+++ b/ControlRoom/Simulator UI/ControlScreens/LocationView.swift
@@ -49,6 +49,7 @@ struct LocationView: View {
                 Map(coordinateRegion: $currentLocation, annotationItems: annotations) { location in
                     MapPin(coordinate: CLLocationCoordinate2D(latitude: location.latitude, longitude: location.longitude), tint: .red)
                 }
+                .frame(height: 300)
 
                 Circle()
                     .stroke(Color.blue, lineWidth: 4)


### PR DESCRIPTION
Quick fix for map view size. `GeometryReader` doesn't work well under `ScrollView` so hardcode a height for now considering the minimal height of window.

| Before | After |
| --- | --- |
| <img width="1130" alt="截屏2022-06-07 下午5 53 32" src="https://user-images.githubusercontent.com/6781789/172510105-b5ab0ce9-767f-4230-8088-26be96b36d4c.png"> | <img width="1062" alt="截屏2022-06-07 下午6 08 39" src="https://user-images.githubusercontent.com/6781789/172510121-2c00e846-e6dd-4958-844a-9b5e8c292f8f.png">
 
 