### PR TITLE
Fix not showing simulator when boot in Xcode 13.4.1 or higher.

### DIFF
--- a/ControlRoom/Controllers/SimCtl+SubCommands.swift
+++ b/ControlRoom/Controllers/SimCtl+SubCommands.swift
@@ -16,6 +16,10 @@ extension SimCtl {
         private init(_ subcommand: String, arguments: [String]) {
             self.arguments = ["simctl", subcommand] + arguments
         }
+      
+        private init(_ subcommand: String) {
+            self.arguments = ["open", subcommand]
+        }
 
         /// Create a new device.
         static func create(name: String, deviceTypeId: String, runtimeId: String? = nil) -> Command {
@@ -68,6 +72,10 @@ extension SimCtl {
         /// Boot a device.
         static func boot(deviceId: String) -> Command {
             Command("boot", arguments: [deviceId])
+        }
+      
+        static func openSimulator(_ tool: DeveloperTool) -> Command {
+            Command("\(tool.path)/Contents/Developer/Applications/Simulator.app")
         }
 
         /// Shutdown a device.

--- a/ControlRoom/Controllers/SimCtl.swift
+++ b/ControlRoom/Controllers/SimCtl.swift
@@ -50,8 +50,9 @@ enum SimCtl: CommandLineCommandExecuter {
         executePropertyList(.listApps(deviceId: simulator, flags: [.json]))
     }
 
-    static func boot(_ simulator: String) {
+    static func boot(_ simulator: String, tool: DeveloperTool) {
         execute(.boot(deviceId: simulator))
+        execute(.openSimulator(tool))
     }
 
     static func shutdown(_ simulator: String) {
@@ -61,9 +62,10 @@ enum SimCtl: CommandLineCommandExecuter {
         execute(.ui(deviceId: simulator, option: .contentSize(contentSize)))
     }
 
-    static func reboot(_ simulator: String) {
+    static func reboot(_ simulator: String, tool: DeveloperTool) {
         execute(.shutdown(.devices([simulator]))) { _ in
             execute(.boot(deviceId: simulator))
+            execute(.openSimulator(tool))
         }
     }
 

--- a/ControlRoom/Controllers/SimulatorsController.swift
+++ b/ControlRoom/Controllers/SimulatorsController.swift
@@ -36,6 +36,8 @@ class SimulatorsController: ObservableObject {
     /// An array of all the applications installed on the selected simulator.
     @Published var applications = [Application]()
 
+    var developerTool: DeveloperTool? = nil
+    
     /// An array of all simulators that were loaded from simctl.
     private var allSimulators = [Simulator]()
 
@@ -72,6 +74,7 @@ class SimulatorsController: ObservableObject {
             .sink { tool in
                 if tool != .empty {
                     self.loadSimulators()
+                    self.developerTool = tool
                 } else {
                     self.loadingStatus = .invalidCommandLineTool
                 }

--- a/ControlRoom/Simulator UI/ControlScreens/SystemView.swift
+++ b/ControlRoom/Simulator UI/ControlScreens/SystemView.swift
@@ -11,6 +11,8 @@ import SwiftUI
 
 /// Controls system-wide settings such as time and appearance.
 struct SystemView: View {
+    @ObservedObject var controller: SimulatorsController
+    
     let simulator: Simulator
 
     @EnvironmentObject var preferences: Preferences
@@ -223,7 +225,9 @@ struct SystemView: View {
         let plistPath = simulator.dataPath + "/Library/Preferences/.GlobalPreferences.plist"
         _ = Process.execute("/usr/bin/xcrun", arguments: ["plutil", "-replace", "AppleLanguages", "-json", "[\"\(language)\" ]", plistPath])
         _ = Process.execute("/usr/bin/xcrun", arguments: ["plutil", "-replace", "AppleLocale", "-string", locale, plistPath])
-        SimCtl.reboot(simulator.id)
+        if let tool = controller.developerTool {
+            SimCtl.reboot(simulator.id, tool: tool)
+        }
     }
 
     /// Starts an immediate iCloud sync.
@@ -320,7 +324,8 @@ struct SystemView: View {
 
 struct SystemView_Previews: PreviewProvider {
     static var previews: some View {
-        SystemView(simulator: .example)
+        SystemView(controller: .init(preferences: .init()),
+                   simulator: .example)
             .environmentObject(Preferences())
     }
 }

--- a/ControlRoom/Simulator UI/ControlView.swift
+++ b/ControlRoom/Simulator UI/ControlView.swift
@@ -47,7 +47,7 @@ struct ControlView: View {
                 .padding(.bottom, 10)
 
                 TabView {
-                    SystemView(simulator: simulator)
+                    SystemView(controller: controller, simulator: simulator)
                     AppView(simulator: simulator, applications: applications)
                     BatteryView(simulator: simulator)
                     LocationView(controller: controller, simulator: simulator)
@@ -62,7 +62,9 @@ struct ControlView: View {
 
     /// Launches the current device.
     func bootDevice() {
-        SimCtl.boot(simulator.udid)
+        if let tool = controller.developerTool {
+            SimCtl.boot(simulator.udid, tool: tool)
+        }
     }
 
     /// Terminates the current device.


### PR DESCRIPTION
Fixes https://github.com/twostraws/ControlRoom/issues/157#issue-1320399015

There is an issue where the Simulator is not visible if the installed version of Xcode is 13.4.1 or higher.
The Simulator is running in the process list but it is not visible.

If there is a better solution, please let me know, I would appreciate it.