### PR TITLE
Work around the status_bar issues on simulators running 16.1+.

### DIFF
--- a/ControlRoom/Controllers/SimCtl.swift
+++ b/ControlRoom/Controllers/SimCtl.swift
@@ -50,8 +50,8 @@ enum SimCtl: CommandLineCommandExecuter {
         executePropertyList(.listApps(deviceId: simulator, flags: [.json]))
     }
 
-    static func boot(_ simulator: String) {
-        execute(.boot(deviceId: simulator))
+    static func boot(_ simulator: Simulator) {
+        execute(.boot(simulator: simulator))
     }
 
     static func shutdown(_ simulator: String) {
@@ -61,9 +61,9 @@ enum SimCtl: CommandLineCommandExecuter {
         execute(.ui(deviceId: simulator, option: .contentSize(contentSize)))
     }
 
-    static func reboot(_ simulator: String) {
-        execute(.shutdown(.devices([simulator]))) { _ in
-            execute(.boot(deviceId: simulator))
+    static func reboot(_ simulator: Simulator) {
+        execute(.shutdown(.devices([simulator.udid]))) { _ in
+            execute(.boot(simulator: simulator))
         }
     }
 
@@ -114,11 +114,11 @@ enum SimCtl: CommandLineCommandExecuter {
     static func setAppearance(_ simulator: String, appearance: UI.Appearance) {
         execute(.ui(deviceId: simulator, option: .appearance(appearance)))
     }
-    static func setLogging(_ simulator: String, enableLogging: Bool) {
-        UserDefaults.standard.set(enableLogging, forKey: "\(simulator).logging")
-        execute(.setLogging(deviceTypeId: simulator, enableLogging: enableLogging))
-        execute(.shutdown(.devices([simulator])))
-        execute(.boot(deviceId: simulator))
+    static func setLogging(_ simulator: Simulator, enableLogging: Bool) {
+        UserDefaults.standard.set(enableLogging, forKey: "\(simulator.udid).logging")
+        execute(.setLogging(deviceTypeId: simulator.udid, enableLogging: enableLogging))
+        execute(.shutdown(.devices([simulator.udid])))
+        execute(.boot(simulator: simulator))
     }
     static func getLogs(_ simulator: String) {
         let source = """

--- a/ControlRoom/Controllers/XcodeCommandLineToolsController.swift
+++ b/ControlRoom/Controllers/XcodeCommandLineToolsController.swift
@@ -41,6 +41,7 @@ private enum XcodeSelect: CommandLineCommandExecuter {
 private extension XcodeSelect {
     struct Command: CommandLineCommand {
         let arguments: [String]
+        var environmentOverrides: [String : String]? { nil }
 
         private init(_ subcommand: String, arguments: [String]) {
             self.arguments = [subcommand] + arguments
@@ -69,6 +70,7 @@ private enum SystemProfiler: CommandLineCommandExecuter {
 private extension SystemProfiler {
     struct Command: CommandLineCommand {
         let arguments: [String]
+        var environmentOverrides: [String : String]? { nil }
 
         private init(_ subcommand: String, arguments: [String]) {
             self.arguments = [subcommand] + arguments

--- a/ControlRoom/Controllers/XcodeCommandLineToolsController.swift
+++ b/ControlRoom/Controllers/XcodeCommandLineToolsController.swift
@@ -41,7 +41,7 @@ private enum XcodeSelect: CommandLineCommandExecuter {
 private extension XcodeSelect {
     struct Command: CommandLineCommand {
         let arguments: [String]
-        var environmentOverrides: [String : String]? { nil }
+        var environmentOverrides: [String: String]? { nil }
 
         private init(_ subcommand: String, arguments: [String]) {
             self.arguments = [subcommand] + arguments
@@ -70,7 +70,7 @@ private enum SystemProfiler: CommandLineCommandExecuter {
 private extension SystemProfiler {
     struct Command: CommandLineCommand {
         let arguments: [String]
-        var environmentOverrides: [String : String]? { nil }
+        var environmentOverrides: [String: String]? { nil }
 
         private init(_ subcommand: String, arguments: [String]) {
             self.arguments = [subcommand] + arguments

--- a/ControlRoom/Helpers/CommandLineExecuter.swift
+++ b/ControlRoom/Helpers/CommandLineExecuter.swift
@@ -43,6 +43,7 @@ enum CommandLineError: Error {
 
 protocol CommandLineCommand {
     var arguments: [String] { get }
+    var environmentOverrides: [String: String]? { get }
 }
 
 protocol CommandLineCommandExecuter {
@@ -51,9 +52,10 @@ protocol CommandLineCommandExecuter {
 }
 
 extension CommandLineCommandExecuter {
-    private static func execute(_ arguments: [String], completion: @escaping (Result<Data, CommandLineError>) -> Void) {
+
+    private static func execute(_ command: Command, completion: @escaping (Result<Data, CommandLineError>) -> Void) {
         DispatchQueue.global(qos: .userInitiated).async {
-            if let data = Process.execute(launchPath, arguments: arguments) {
+            if let data = Process.execute(launchPath, arguments: command.arguments, environmentOverrides: command.environmentOverrides) {
                 completion(.success(data))
             } else {
                 completion(.failure(.missingCommand))
@@ -73,10 +75,10 @@ extension CommandLineCommandExecuter {
         return task
     }
 
-    static func execute(_ arguments: [String]) -> PassthroughSubject<Data, CommandLineError> {
+    static func executeSubject(_ command: Command) -> PassthroughSubject<Data, CommandLineError> {
         let publisher = PassthroughSubject<Data, CommandLineError>()
 
-        execute(arguments) { result in
+        execute(command) { result in
             switch result {
             case .success(let data):
                 publisher.send(data)
@@ -88,24 +90,20 @@ extension CommandLineCommandExecuter {
 
         return publisher
     }
-
-    static func executeSubject(_ command: Command) -> PassthroughSubject<Data, CommandLineError> {
-        execute(command.arguments)
-    }
     static func execute(_ command: Command, completion: ((Result<Data, CommandLineError>) -> Void)? = nil) {
-        execute(command.arguments, completion: completion ?? { _ in })
+        execute(command, completion: completion ?? { _ in })
     }
 
     static func executeJSON<T: Decodable>(_ command: Command) -> AnyPublisher<T, CommandLineError> {
-        executeAndDecode(command.arguments, decoder: JSONDecoder())
+        executeAndDecode(command, decoder: JSONDecoder())
     }
 
     static func executePropertyList<T: Decodable>(_ command: Command) -> AnyPublisher<T, CommandLineError> {
-        executeAndDecode(command.arguments, decoder: PropertyListDecoder())
+        executeAndDecode(command, decoder: PropertyListDecoder())
     }
 
-    private static func executeAndDecode<Item, Decoder>(_ arguments: [String], decoder: Decoder) -> AnyPublisher<Item, CommandLineError> where Item: Decodable, Decoder: TopLevelDecoder, Decoder.Input == Data {
-        execute(arguments)
+    private static func executeAndDecode<Item, Decoder>(_ command: Command, decoder: Decoder) -> AnyPublisher<Item, CommandLineError> where Item: Decodable, Decoder: TopLevelDecoder, Decoder.Input == Data {
+        executeSubject(command)
             .decode(type: Item.self, decoder: decoder)
             .mapError { error -> CommandLineError in
                 if error is DecodingError {

--- a/ControlRoom/Helpers/FFMPEGConverter.swift
+++ b/ControlRoom/Helpers/FFMPEGConverter.swift
@@ -30,8 +30,8 @@ enum FFMPEGConverter: CommandLineCommandExecuter {
                 outPath                         // Output file
             ]
         }
-        
-        var environmentOverrides: [String : String]? { nil }
+
+        var environmentOverrides: [String: String]? { nil }
     }
 
     static let available: Bool = {

--- a/ControlRoom/Helpers/FFMPEGConverter.swift
+++ b/ControlRoom/Helpers/FFMPEGConverter.swift
@@ -30,6 +30,8 @@ enum FFMPEGConverter: CommandLineCommandExecuter {
                 outPath                         // Output file
             ]
         }
+        
+        var environmentOverrides: [String : String]? { nil }
     }
 
     static let available: Bool = {

--- a/ControlRoom/Helpers/Process.swift
+++ b/ControlRoom/Helpers/Process.swift
@@ -10,9 +10,18 @@ import Foundation
 
 extension Process {
     @objc static func execute(_ command: String, arguments: [String]) -> Data? {
+        Self.execute(command, arguments: arguments, environmentOverrides: nil)
+    }
+    
+    static func execute(_ command: String, arguments: [String], environmentOverrides: [String: String]? = nil) -> Data? {
         let task = Process()
         task.launchPath = command
         task.arguments = arguments
+        if let environmentOverrides {
+            var environment = ProcessInfo.processInfo.environment
+            environment.merge(environmentOverrides) { (_, new) in new }
+            task.environment = environment
+        }
 
         let pipe = Pipe()
         task.standardOutput = pipe

--- a/ControlRoom/Helpers/Process.swift
+++ b/ControlRoom/Helpers/Process.swift
@@ -12,7 +12,7 @@ extension Process {
     @objc static func execute(_ command: String, arguments: [String]) -> Data? {
         Self.execute(command, arguments: arguments, environmentOverrides: nil)
     }
-    
+
     static func execute(_ command: String, arguments: [String], environmentOverrides: [String: String]? = nil) -> Data? {
         let task = Process()
         task.launchPath = command

--- a/ControlRoom/Simulator UI/ControlScreens/SystemView.swift
+++ b/ControlRoom/Simulator UI/ControlScreens/SystemView.swift
@@ -223,7 +223,7 @@ struct SystemView: View {
         let plistPath = simulator.dataPath + "/Library/Preferences/.GlobalPreferences.plist"
         _ = Process.execute("/usr/bin/xcrun", arguments: ["plutil", "-replace", "AppleLanguages", "-json", "[\"\(language)\" ]", plistPath])
         _ = Process.execute("/usr/bin/xcrun", arguments: ["plutil", "-replace", "AppleLocale", "-string", locale, plistPath])
-        SimCtl.reboot(simulator.id)
+        SimCtl.reboot(simulator)
     }
 
     /// Starts an immediate iCloud sync.
@@ -233,10 +233,10 @@ struct SystemView: View {
     /// Update logging.
     func updateLogging() {
         if isLoggingEnabled {
-            SimCtl.setLogging(simulator.udid, enableLogging: false)
+            SimCtl.setLogging(simulator, enableLogging: false)
             isLoggingEnabled = false
         } else {
-            SimCtl.setLogging(simulator.udid, enableLogging: true)
+            SimCtl.setLogging(simulator, enableLogging: true)
             isLoggingEnabled = true
         }
     }

--- a/ControlRoom/Simulator UI/ControlView.swift
+++ b/ControlRoom/Simulator UI/ControlView.swift
@@ -62,7 +62,7 @@ struct ControlView: View {
 
     /// Launches the current device.
     func bootDevice() {
-        SimCtl.boot(simulator.udid)
+        SimCtl.boot(simulator)
     }
 
     /// Terminates the current device.

--- a/ControlRoomTests/Controllers/SimCtl+SubCommandsTests.swift
+++ b/ControlRoomTests/Controllers/SimCtl+SubCommandsTests.swift
@@ -17,6 +17,22 @@ class SimCtlSubCommandsTests: XCTestCase {
         XCTAssertEqual(command.arguments, expectation)
     }
 
+    func testBoot() throws {
+        let getSimulator: (String) -> Simulator = { buildVersion in
+            let runtime = Runtime(buildversion: buildVersion, identifier: "made-up", version: "version", isAvailable: true, name: "iPhone 14")
+            return Simulator(name: "iPhone 14", udid: "made-up-udid", state: .shutdown, runtime: runtime, deviceType: nil, dataPath: "fake-path")
+        }
+        let expectedArguments = ["simctl", "boot", "made-up-udid"]
+
+        let command160: SimCtl.Command = .boot(simulator: getSimulator("16.0"))
+        XCTAssertEqual(command160.arguments, expectedArguments)
+        XCTAssertEqual(command160.environmentOverrides, nil)
+
+        let command161: SimCtl.Command = .boot(simulator: getSimulator("16.1"))
+        XCTAssertEqual(command161.arguments, expectedArguments)
+        XCTAssertEqual(command161.environmentOverrides, ["SIMCTL_CHILD_SIMULATOR_RUNTIME_VERSION": "16.0"])
+    }
+
     func testRecordAVideo() throws {
         let command: SimCtl.Command = .io(deviceId: "device1", operation: .recordVideo(codec: .h264, url: "~/my-video.mov"))
         let expectation = ["simctl", "io", "device1", "recordVideo", "--codec=h264", "~/my-video.mov"]


### PR DESCRIPTION
Since 16.1, `xcrun simctl status_bar` commands have no effect. Thanks to @saagarjha's info here we have a workaround by setting the environment variable `SIMCTL_CHILD_SIMULATOR_RUNTIME_VERSION=16.0` when booting the device: https://federated.saagarjha.com/notice/AUwNsSsOOCWFc8qCvY