### PR TITLE
Updated ProgressView to use controlSize instead of scaleEffect

### DIFF
--- a/ControlRoom/Loading/LoadingView.swift
+++ b/ControlRoom/Loading/LoadingView.swift
@@ -15,7 +15,7 @@ struct LoadingView: View {
             .padding()
         ProgressView()
             .progressViewStyle(CircularProgressViewStyle(tint: .gray))
-            .scaleEffect(2)
+            .controlSize(.large)
     }
 }
 


### PR DESCRIPTION
Currently when opening ControlRoom, the loading spinner appears blurry due to using the 'scaleEffect' modifier. I've replaced this with the 'controlSize' modifier so that no longer happens whilst preserving the larger progress spinner.