### PR TITLE
Support alternate Xcode locations

### DIFF
--- a/ControlRoom.xcodeproj/project.pbxproj
+++ b/ControlRoom.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		55DF68B923F86C0700E717D3 /* ContextMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DF68B823F86C0700E717D3 /* ContextMenu.swift */; };
 		55DF68BB23F8BE8D00E717D3 /* CreateSimulatorActionSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DF68BA23F8BE8D00E717D3 /* CreateSimulatorActionSheet.swift */; };
 		55DF68BD23F8C76800E717D3 /* Collection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DF68BC23F8C76800E717D3 /* Collection.swift */; };
+		5FA79DA92A5752A9006F5477 /* XcodeHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FA79DA82A5752A9006F5477 /* XcodeHelper.swift */; };
 		70BE435A23F54B7200FD6282 /* LocationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70BE435923F54B7200FD6282 /* LocationView.swift */; };
 		AC472CCF240D46D7007FF521 /* KeyedEncodingContainer-NotEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC472CCE240D46D7007FF521 /* KeyedEncodingContainer-NotEmpty.swift */; };
 		AC472CFB240D5F22007FF521 /* NotificationEditorView.strings in Resources */ = {isa = PBXBuildFile; fileRef = AC472CFA240D5F22007FF521 /* NotificationEditorView.strings */; };
@@ -150,6 +151,7 @@
 		55DF68B823F86C0700E717D3 /* ContextMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextMenu.swift; sourceTree = "<group>"; };
 		55DF68BA23F8BE8D00E717D3 /* CreateSimulatorActionSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateSimulatorActionSheet.swift; sourceTree = "<group>"; };
 		55DF68BC23F8C76800E717D3 /* Collection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Collection.swift; sourceTree = "<group>"; };
+		5FA79DA82A5752A9006F5477 /* XcodeHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcodeHelper.swift; sourceTree = "<group>"; };
 		70BE435923F54B7200FD6282 /* LocationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationView.swift; sourceTree = "<group>"; };
 		AC472CCE240D46D7007FF521 /* KeyedEncodingContainer-NotEmpty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KeyedEncodingContainer-NotEmpty.swift"; sourceTree = "<group>"; };
 		AC472CFA240D5F22007FF521 /* NotificationEditorView.strings */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; path = NotificationEditorView.strings; sourceTree = "<group>"; };
@@ -280,6 +282,7 @@
 				555A145B23F70CCF00313BC5 /* Process.swift */,
 				551F8CF623F4BEAC0006D1BD /* TypeIdentifier.swift */,
 				515E56DE2A14499B003B4F5A /* XcodeColorSet.swift */,
+				5FA79DA82A5752A9006F5477 /* XcodeHelper.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -648,6 +651,7 @@
 				551F8CF523F4AF7B0006D1BD /* FilterField.swift in Sources */,
 				AC472CCF240D46D7007FF521 /* KeyedEncodingContainer-NotEmpty.swift in Sources */,
 				51AB56E72A140D53002B5A67 /* NSColor-Conversions.swift in Sources */,
+				5FA79DA92A5752A9006F5477 /* XcodeHelper.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ControlRoom/Controllers/ChromeRendering/ChromeRenderer.swift
+++ b/ControlRoom/Controllers/ChromeRendering/ChromeRenderer.swift
@@ -84,9 +84,10 @@ class ChromeRenderer {
 
         // We start by loading this device's profile, which describes
         // what type of chrome we have and also the screen scale.
-        var profileURL = URL(filePath: "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/DeviceTypes")
-        profileURL.append(path: "\(deviceName).simdevicetype")
-        profileURL.append(path: "/Contents/Resources/profile.plist")
+        let developerPath = XcodeHelper.getDeveloperPath()
+        let basePath = "\(developerPath)/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles"
+        let profilePath = "\(basePath)/DeviceTypes/\(deviceName).simdevicetype/Contents/Resources/profile.plist"
+        let profileURL = URL(filePath: profilePath)
 
         let profileData = try Data(contentsOf: profileURL)
         device = try PropertyListDecoder().decode(SimulatorDevice.self, from: profileData)
@@ -97,9 +98,10 @@ class ChromeRenderer {
         let mainIdentifier = device.chromeIdentifier.components(separatedBy: ".").last ?? "phone"
 
         // Now use that last part to find the PDFs and placement JSON.
-        baseURL = URL(filePath: "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Chrome/\(mainIdentifier).simdevicechrome/Contents/Resources")
+        let chromePath = "\(basePath)/Chrome/\(mainIdentifier).simdevicechrome/Contents/Resources"
+        baseURL = URL(filePath: chromePath)
 
-        let chromeURL = baseURL.appending(path: "chrome.json")
+        let chromeURL = URL(filePath: "\(chromePath)/chrome.json")
         let chromeData = try Data(contentsOf: chromeURL)
 
         chrome = try JSONDecoder().decode(SimulatorChrome.self, from: chromeData)

--- a/ControlRoom/Helpers/XcodeHelper.swift
+++ b/ControlRoom/Helpers/XcodeHelper.swift
@@ -1,0 +1,23 @@
+//
+//  XcodeHelper.swift
+//  ControlRoom
+//
+//  Created by Stuart Isaac on 7/6/23.
+//  Copyright © 2023 Paul Hudson. All rights reserved.
+//
+
+import Foundation
+
+enum XcodeHelper {
+    static func getDeveloperPath() -> String {
+        let defaultDeveloperPath = "/Applications/Xcode.app/Contents/Developer"
+        let developerPath: String
+        if let developerPathData = Process.execute("/usr/bin/xcode-select", arguments: ["-p"]) {
+            let result = String(decoding: developerPathData, as: UTF8.self).replacingOccurrences(of: "\\n+$", with: "", options: .regularExpression)
+            developerPath = result.isEmpty ? defaultDeveloperPath : result
+        } else {
+            developerPath = defaultDeveloperPath
+        }
+        return developerPath
+    }
+}


### PR DESCRIPTION
When adding device chrome to screen shots, support Xcode being installed in places other than `/Applications/Xcode.app` by getting the path from `xcode-select`.