### PR TITLE
Fix: Task Wrapper for Actor-Isolated Method in ColorsView

### DIFF
--- a/ControlRoom/Simulator UI/ControlScreens/ColorsView.swift
+++ b/ControlRoom/Simulator UI/ControlScreens/ColorsView.swift
@@ -99,7 +99,10 @@ struct ColorsView: View {
                     TableRow(color)
                         .itemProvider {
                             let provider = NSItemProvider()
-                            provider.register(assetCatalogData(for: color))
+                            Task {
+                                    let catalogData = assetCatalogData(for: color)
+                                    provider.register(catalogData)
+                            }
                             return provider
                         }
                 }


### PR DESCRIPTION
### Description:
This PR resolves a runtime error in ColorsView due to calling the actor-isolated method assetCatalogData(for:) synchronously in a nonisolated context by wrapping it inside a Task initializer.

### Changes:

```
Task {
    let catalogData = assetCatalogData(for: color)
    provider.register(catalogData)
}
```
### Testing:
Tested on macOS 13.5.2 (22G91) and Xcode 15.0 (15A240d), with no new SwiftLint warnings or errors.