### PR TITLE
Add basic CI support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: Xcode - Build and Test
+    
+on: [pull_request]
+
+jobs:
+  build:
+    name: 'Build and test: Debug'
+    runs-on: macos-13
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Selected Xcode version 
+        run: |
+          xcode-select -p
+      - name: Build and test
+        run: |
+          xcodebuild clean build analyze test -project ControlRoom.xcodeproj -scheme 'Debug - ControlRoom' -destination 'platform=macOS' CONFIGURATION_BUILD_DIR=$(pwd)/build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO | xcpretty

--- a/ControlRoom.xcodeproj/project.pbxproj
+++ b/ControlRoom.xcodeproj/project.pbxproj
@@ -881,6 +881,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.hackingwithswift.ControlRoomTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -903,6 +904,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.hackingwithswift.ControlRoomTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;


### PR DESCRIPTION
This adds a very basic CI support to the repo. This should help to avoid to break `main` after a not so thoroughly tested merges. 

Of course the configuration can be expanded and tuned, but it should be a good starting point 🤞 .

A sample run can be found [here](https://github.com/lechuckcaptain/ControlRoom/actions/runs/6304860921).