### PR TITLE
Added a way to save simulated locations to a list

### DIFF
--- a/ControlRoom.xcodeproj/project.pbxproj
+++ b/ControlRoom.xcodeproj/project.pbxproj
@@ -77,6 +77,8 @@
 		ACDF076823F7E91A00597B3B /* ApplicationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACDF076723F7E91A00597B3B /* ApplicationType.swift */; };
 		B07F584923F99A1700256D5D /* SimCtl+SubCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = B07F584823F99A1700256D5D /* SimCtl+SubCommands.swift */; };
 		B07F585123F9F83800256D5D /* SimCtl+SubCommandsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B07F585023F9F83800256D5D /* SimCtl+SubCommandsTests.swift */; };
+		E04B47322B07B66F00DAE338 /* LocationsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E04B47312B07B66F00DAE338 /* LocationsController.swift */; };
+		E04B47342B07B72C00DAE338 /* Location.swift in Sources */ = {isa = PBXBuildFile; fileRef = E04B47332B07B72C00DAE338 /* Location.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -165,6 +167,8 @@
 		B07F584E23F9F83800256D5D /* ControlRoomTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ControlRoomTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B07F585023F9F83800256D5D /* SimCtl+SubCommandsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SimCtl+SubCommandsTests.swift"; sourceTree = "<group>"; };
 		B07F585223F9F83800256D5D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		E04B47312B07B66F00DAE338 /* LocationsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationsController.swift; sourceTree = "<group>"; };
+		E04B47332B07B72C00DAE338 /* Location.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Location.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -277,6 +281,7 @@
 				51AB56EC2A143B90002B5A67 /* Double-Rounding.swift */,
 				41C44ACC2616FCB50016B1E4 /* FFMPEGConverter.swift */,
 				5534158523FE1AC4005C0A41 /* Flow.swift */,
+				E04B47332B07B72C00DAE338 /* Location.swift */,
 				51AB56E62A140D53002B5A67 /* NSColor-Conversions.swift */,
 				51AB56EE2A143BC0002B5A67 /* PickedColor.swift */,
 				555A145B23F70CCF00313BC5 /* Process.swift */,
@@ -387,6 +392,7 @@
 				51AB56EA2A141C57002B5A67 /* ColorHistoryController.swift */,
 				51AB56DF2A13D189002B5A67 /* DeepLinksController.swift */,
 				5179289925C37D2A000F6F3A /* KeyboardShortcuts.swift */,
+				E04B47312B07B66F00DAE338 /* LocationsController.swift */,
 				5523A7E023F99D7200F25EEC /* Preferences.swift */,
 				ACCD798D240AE82C0004ECE5 /* PushNotification.swift */,
 				551F8CFD23F5C9EF0006D1BD /* SimCtl.swift */,
@@ -597,6 +603,7 @@
 				551F8CED23F489A50006D1BD /* SidebarView.swift in Sources */,
 				551F8CEF23F48B030006D1BD /* SplitLayoutView.swift in Sources */,
 				551F8CFE23F5C9EF0006D1BD /* SimCtl.swift in Sources */,
+				E04B47322B07B66F00DAE338 /* LocationsController.swift in Sources */,
 				54C2092B27DBDE2200E47016 /* DocumentPickerConfig.swift in Sources */,
 				ACCD798E240AE82C0004ECE5 /* PushNotification.swift in Sources */,
 				517928C225C47392000F6F3A /* AVAssetToGIF.swift in Sources */,
@@ -621,6 +628,7 @@
 				511BA57D23F3FFEA00E3E660 /* ControlRoomApp.swift in Sources */,
 				511BA5A223F41A5900E3E660 /* Binding-OnChange.swift in Sources */,
 				55DF68BD23F8C76800E717D3 /* Collection.swift in Sources */,
+				E04B47342B07B72C00DAE338 /* Location.swift in Sources */,
 				51AB56D92A127F9F002B5A67 /* ChromeRenderer.swift in Sources */,
 				511BA59823F4096800E3E660 /* Simulator.swift in Sources */,
 				51AB56DE2A13D14A002B5A67 /* DeepLink.swift in Sources */,

--- a/ControlRoom/Controllers/LocationsController.swift
+++ b/ControlRoom/Controllers/LocationsController.swift
@@ -8,11 +8,15 @@
 
 import Foundation
 
+/// Loads, manages, and saves the user's collection of saved locations.
 class LocationsController: ObservableObject {
+    /// The list of saved locations the user has created.
     @Published private(set) var locations: [Location]
 
+    /// The UserDefaults key where we save locations.
     private let defaultsKey = "CRSavedLocations"
 
+    /// Attempts to load saved locations from UserDefaults, or creates an empty array otherwise.
     init() {
         if let data = UserDefaults.standard.data(forKey: defaultsKey) {
             if let decoded = try? JSONDecoder().decode([Location].self, from: data) {
@@ -24,12 +28,19 @@ class LocationsController: ObservableObject {
         locations = []
     }
 
+    /// Creates a new Location instance from name, latitude, and longitude.
+    /// - Parameters:
+    ///   - name: The user's name for this location.
+    ///   - latitude: Latitude.
+    ///   - longitude: Longitude.
     func create(name: String, latitude: Double, longitude: Double) {
         let location = Location(id: UUID(), name: name, latitude: latitude, longitude: longitude)
         locations.append(location)
         save()
     }
 
+    /// Deletes a Location instance based on its ID.
+    /// - Parameter itemID: The identifier of the location we want to delete.
     func delete(_ itemID: Location.ID?) {
         guard let itemID else { return }
 
@@ -40,11 +51,9 @@ class LocationsController: ObservableObject {
         save()
     }
 
-    func sort(using comparator: [KeyPathComparator<Location>]) {
-        locations.sort(using: comparator)
-        save()
-    }
-
+    /// Returns a Location instance based on its ID.
+    /// - Parameter itemID: The identifier of the location we want to return.
+    /// - Returns: The Location instance with the request ID, if it could be found.
     func item(with itemID: Location.ID?) -> Location? {
         guard let itemID else { return nil }
 
@@ -53,7 +62,7 @@ class LocationsController: ObservableObject {
         }
     }
 
-    /// Writes the user's deep links to UserDefaults.
+    /// Writes the user's saved locations to UserDefaults.
     private func save() {
         if let encoded = try? JSONEncoder().encode(locations) {
             UserDefaults.standard.set(encoded, forKey: defaultsKey)

--- a/ControlRoom/Controllers/LocationsController.swift
+++ b/ControlRoom/Controllers/LocationsController.swift
@@ -45,6 +45,14 @@ class LocationsController: ObservableObject {
         save()
     }
 
+    func item(with itemID: Location.ID?) -> Location? {
+        guard let itemID else { return nil }
+
+        return locations.first { location in
+            location.id == itemID
+        }
+    }
+
     /// Writes the user's deep links to UserDefaults.
     private func save() {
         if let encoded = try? JSONEncoder().encode(locations) {

--- a/ControlRoom/Controllers/LocationsController.swift
+++ b/ControlRoom/Controllers/LocationsController.swift
@@ -1,0 +1,54 @@
+//
+//  LocationsController.swift
+//  ControlRoom
+//
+//  Created by Alexander Chekel on 17.11.2023.
+//  Copyright © 2023 Paul Hudson. All rights reserved.
+//
+
+import Foundation
+
+class LocationsController: ObservableObject {
+    @Published private(set) var locations: [Location]
+
+    private let defaultsKey = "CRSavedLocations"
+
+    init() {
+        if let data = UserDefaults.standard.data(forKey: defaultsKey) {
+            if let decoded = try? JSONDecoder().decode([Location].self, from: data) {
+                locations = decoded
+                return
+            }
+        }
+
+        locations = []
+    }
+
+    func create(name: String, latitude: Double, longitude: Double) {
+        let location = Location(id: UUID(), name: name, latitude: latitude, longitude: longitude)
+        locations.append(location)
+        save()
+    }
+
+    func delete(_ itemID: Location.ID?) {
+        guard let itemID else { return }
+
+        locations.removeAll { location in
+            location.id == itemID
+        }
+
+        save()
+    }
+
+    func sort(using comparator: [KeyPathComparator<Location>]) {
+        locations.sort(using: comparator)
+        save()
+    }
+
+    /// Writes the user's deep links to UserDefaults.
+    private func save() {
+        if let encoded = try? JSONEncoder().encode(locations) {
+            UserDefaults.standard.set(encoded, forKey: defaultsKey)
+        }
+    }
+}

--- a/ControlRoom/Helpers/Location.swift
+++ b/ControlRoom/Helpers/Location.swift
@@ -1,0 +1,16 @@
+//
+//  Location.swift
+//  ControlRoom
+//
+//  Created by Alexander Chekel on 17.11.2023.
+//  Copyright © 2023 Paul Hudson. All rights reserved.
+//
+
+import Foundation
+
+struct Location: Identifiable, Codable {
+    var id: UUID
+    var name: String
+    var latitude: Double
+    var longitude: Double
+}

--- a/ControlRoom/Helpers/Location.swift
+++ b/ControlRoom/Helpers/Location.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+/// The user's saved location.
 struct Location: Identifiable, Codable {
     var id: UUID
     var name: String

--- a/ControlRoom/Simulator UI/ControlScreens/LocationView.swift
+++ b/ControlRoom/Simulator UI/ControlScreens/LocationView.swift
@@ -74,32 +74,35 @@ struct LocationView: View {
                     }
                 }
 
-                HStack {
-                    ZStack {
-                        Map(coordinateRegion: $currentLocation, annotationItems: annotations) { location in
-                            MapMarker(coordinate: CLLocationCoordinate2D(latitude: location.latitude, longitude: location.longitude), tint: .red)
+                GeometryReader { proxy in
+                    HStack {
+                        ZStack {
+                            Map(coordinateRegion: $currentLocation, annotationItems: annotations) { location in
+                                MapMarker(coordinate: CLLocationCoordinate2D(latitude: location.latitude, longitude: location.longitude), tint: .red)
+                            }
+                            .cornerRadius(5)
+
+                            Circle()
+                                .stroke(Color.blue, lineWidth: 4)
+                                .frame(width: 20)
+                        }
+                        .keyboardShortcut(.defaultAction)
+
+                        Table(of: Location.self, selection: $previouslyPickedLocation.onChange(updatePickedLocation)) {
+                            TableColumn("Saved locations", value: \.name)
+                        } rows: {
+                            ForEach(locationsController.locations) { location in
+                                TableRow(location)
+                                    .contextMenu {
+                                        Button("Delete") {
+                                            locationsController.delete(location.id)
+                                        }
+                                    }
+                            }
                         }
                         .cornerRadius(5)
-
-                        Circle()
-                            .stroke(Color.blue, lineWidth: 4)
-                            .frame(width: 20)
+                        .frame(width: proxy.size.width * 0.3)
                     }
-                    .keyboardShortcut(.defaultAction)
-
-                    Table(of: Location.self, selection: $previouslyPickedLocation.onChange(updatePickedLocation)) {
-                        TableColumn("Saved locations", value: \.name)
-                    } rows: {
-                        ForEach(locationsController.locations) { location in
-                            TableRow(location)
-                                .contextMenu {
-                                    Button("Delete") {
-                                        locationsController.delete(location.id)
-                                    }
-                                }
-                        }
-                    }
-                    .cornerRadius(5)
                 }
                 .padding(.bottom, 10)
 

--- a/ControlRoom/Simulator UI/ControlScreens/LocationView.swift
+++ b/ControlRoom/Simulator UI/ControlScreens/LocationView.swift
@@ -17,10 +17,14 @@ struct LocationView: View {
     static let DEFAULT_LAT = 37.323056
     static let DEFAULT_LNG = -122.031944
 
+    /// Saved locations controller.
     @StateObject private var locationsController = LocationsController()
+    /// Current table selection binding.
     @State private var previouslyPickedLocation: Location.ID?
 
+    /// Name of the location user is about save.
     @State private var newLocationName = ""
+    /// Indicates whether save location alert is currently presented.
     @State private var isShowingNewLocationAlert = false
 
     @State private var latitudeText = "\(DEFAULT_LAT)"
@@ -154,6 +158,7 @@ struct LocationView: View {
         changeLocation()
     }
 
+    /// Saves currently selected location to user's collection.
     private func savePickedLocation() {
         let latitude = currentLocation.center.latitude
         let longitude = currentLocation.center.longitude
@@ -162,6 +167,7 @@ struct LocationView: View {
         newLocationName = ""
     }
 
+    /// Updates current location on the map when saved location is selected from the table.
     private func updatePickedLocation() {
         guard let location = locationsController.item(with: previouslyPickedLocation) else { return }
 

--- a/ControlRoom/Simulator UI/ControlScreens/LocationView.swift
+++ b/ControlRoom/Simulator UI/ControlScreens/LocationView.swift
@@ -19,6 +19,10 @@ struct LocationView: View {
 
     @StateObject private var locationsController = LocationsController()
     @State private var previouslyPickedLocation: Location.ID?
+
+    @State private var newLocationName = ""
+    @State private var isShowingNewLocationAlert = false
+
     @State private var latitudeText = "\(DEFAULT_LAT)"
     @State private var longitudeText = "\(DEFAULT_LNG)"
     /// The location that is being simulated
@@ -88,6 +92,11 @@ struct LocationView: View {
                     } rows: {
                         ForEach(locationsController.locations) { location in
                             TableRow(location)
+                                .contextMenu {
+                                    Button("Delete") {
+                                        locationsController.delete(location.id)
+                                    }
+                                }
                         }
                     }
                     .cornerRadius(5)
@@ -101,6 +110,9 @@ struct LocationView: View {
                     Toggle("Jitter location", isOn: $isJittering)
                         .toggleStyle(.checkbox)
                     Button("Activate", action: changeLocation)
+                    Button("Save") {
+                        isShowingNewLocationAlert.toggle()
+                    }
                 }
             }
         }
@@ -115,6 +127,11 @@ struct LocationView: View {
             }
 
             jitterLocation()
+        }
+        .alert("Save location", isPresented: $isShowingNewLocationAlert) {
+            TextField("Name", text: $newLocationName)
+            Button("Save", action: savePickedLocation)
+            Button("Cancel", role: .cancel) { }
         }
     }
 
@@ -132,6 +149,14 @@ struct LocationView: View {
         let long = currentLocation.center.longitude + (Double.random(in: -0.0001...0.0001))
         jitteredLocation = CLLocationCoordinate2D(latitude: lat, longitude: long)
         changeLocation()
+    }
+
+    private func savePickedLocation() {
+        let latitude = currentLocation.center.latitude
+        let longitude = currentLocation.center.longitude
+        locationsController.create(name: newLocationName, latitude: latitude, longitude: longitude)
+
+        newLocationName = ""
     }
 
     private func updatePickedLocation() {

--- a/ControlRoom/Simulator UI/ControlScreens/LocationView.swift
+++ b/ControlRoom/Simulator UI/ControlScreens/LocationView.swift
@@ -162,6 +162,9 @@ struct LocationView: View {
     private func updatePickedLocation() {
         guard let location = locationsController.item(with: previouslyPickedLocation) else { return }
 
-        currentLocation.center = CLLocationCoordinate2D(latitude: location.latitude, longitude: location.longitude)
+        currentLocation = MKCoordinateRegion(
+            center: CLLocationCoordinate2D(latitude: location.latitude, longitude: location.longitude),
+            span: MKCoordinateSpan(latitudeDelta: 15, longitudeDelta: 15)
+        )
     }
 }


### PR DESCRIPTION
Saving and quickly applying simulated locations is a common workflow for me, so I've decided to implement this feature in ControlRoom. 

This PR adds a table next to the map view that lists user's saved locations. Currently selected location can be saved by clicking "Save" button in the bottom right corner. 

Screenshots:
<img width="900" alt="Screenshot 2023-11-17 at 10 36 12 PM" src="https://github.com/twostraws/ControlRoom/assets/26207942/fd4a4ab8-3cd8-4599-a858-275d54117065">

<img width="900" alt="Screenshot 2023-11-17 at 10 36 41 PM" src="https://github.com/twostraws/ControlRoom/assets/26207942/82ec5142-5209-4880-8408-14313d347272">

