### PR TITLE
feat: extract subviews on extension

### DIFF
--- a/ControlRoom.xcodeproj/project.pbxproj
+++ b/ControlRoom.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		3C09AF722BE8B4E800C303C0 /* SettingsView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C09AF712BE8B4E800C303C0 /* SettingsView+Extension.swift */; };
 		3C13FF952BEF499400060A5C /* NotificationsFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C13FF942BEF499400060A5C /* NotificationsFormView.swift */; };
+		3C13FF972BEF4AAE00060A5C /* PickersFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C13FF962BEF4AAE00060A5C /* PickersFormView.swift */; };
 		3CF07C312BEF48D200770363 /* TogglesFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CF07C302BEF48D200770363 /* TogglesFormView.swift */; };
 		41C44ACD2616FCB50016B1E4 /* FFMPEGConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41C44ACC2616FCB50016B1E4 /* FFMPEGConverter.swift */; };
 		510871F225C317830009E39F /* SimulatorAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510871F125C317830009E39F /* SimulatorAction.swift */; };
@@ -100,6 +101,7 @@
 /* Begin PBXFileReference section */
 		3C09AF712BE8B4E800C303C0 /* SettingsView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SettingsView+Extension.swift"; sourceTree = "<group>"; };
 		3C13FF942BEF499400060A5C /* NotificationsFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsFormView.swift; sourceTree = "<group>"; };
+		3C13FF962BEF4AAE00060A5C /* PickersFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PickersFormView.swift; sourceTree = "<group>"; };
 		3CF07C302BEF48D200770363 /* TogglesFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TogglesFormView.swift; sourceTree = "<group>"; };
 		41C44ACC2616FCB50016B1E4 /* FFMPEGConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FFMPEGConverter.swift; sourceTree = "<group>"; };
 		510871F125C317830009E39F /* SimulatorAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulatorAction.swift; sourceTree = "<group>"; };
@@ -427,6 +429,7 @@
 				3C09AF712BE8B4E800C303C0 /* SettingsView+Extension.swift */,
 				3CF07C302BEF48D200770363 /* TogglesFormView.swift */,
 				3C13FF942BEF499400060A5C /* NotificationsFormView.swift */,
+				3C13FF962BEF4AAE00060A5C /* PickersFormView.swift */,
 			);
 			path = "Settings UI";
 			sourceTree = "<group>";
@@ -691,6 +694,7 @@
 				551F8CF523F4AF7B0006D1BD /* SearchField.swift in Sources */,
 				AC472CCF240D46D7007FF521 /* KeyedEncodingContainer-NotEmpty.swift in Sources */,
 				51AB56E72A140D53002B5A67 /* NSColor-Conversions.swift in Sources */,
+				3C13FF972BEF4AAE00060A5C /* PickersFormView.swift in Sources */,
 				5FA79DA92A5752A9006F5477 /* XcodeHelper.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ControlRoom.xcodeproj/project.pbxproj
+++ b/ControlRoom.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3C09AF722BE8B4E800C303C0 /* SettingsView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C09AF712BE8B4E800C303C0 /* SettingsView+Extension.swift */; };
 		41C44ACD2616FCB50016B1E4 /* FFMPEGConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41C44ACC2616FCB50016B1E4 /* FFMPEGConverter.swift */; };
 		510871F225C317830009E39F /* SimulatorAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510871F125C317830009E39F /* SimulatorAction.swift */; };
 		511BA57D23F3FFEA00E3E660 /* ControlRoomApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511BA57C23F3FFEA00E3E660 /* ControlRoomApp.swift */; };
@@ -95,6 +96,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		3C09AF712BE8B4E800C303C0 /* SettingsView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SettingsView+Extension.swift"; sourceTree = "<group>"; };
 		41C44ACC2616FCB50016B1E4 /* FFMPEGConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FFMPEGConverter.swift; sourceTree = "<group>"; };
 		510871F125C317830009E39F /* SimulatorAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulatorAction.swift; sourceTree = "<group>"; };
 		511BA57923F3FFEA00E3E660 /* Control Room.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Control Room.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -418,6 +420,7 @@
 			isa = PBXGroup;
 			children = (
 				55AF68B423F9CFD600C5D87A /* SettingsView.swift */,
+				3C09AF712BE8B4E800C303C0 /* SettingsView+Extension.swift */,
 			);
 			path = "Settings UI";
 			sourceTree = "<group>";
@@ -642,6 +645,7 @@
 				551F8CF923F4C45A0006D1BD /* SimulatorSidebarView.swift in Sources */,
 				54C2092827DBDB6F00E47016 /* DocumentPicker.swift in Sources */,
 				51203A512A09588A00CBE517 /* Capture.swift in Sources */,
+				3C09AF722BE8B4E800C303C0 /* SettingsView+Extension.swift in Sources */,
 				511BA59C23F4172400E3E660 /* SystemView.swift in Sources */,
 				54C2092D27DBDE7500E47016 /* UTType+Extension.swift in Sources */,
 				511BA57D23F3FFEA00E3E660 /* ControlRoomApp.swift in Sources */,
@@ -857,8 +861,11 @@
 				MARKETING_VERSION = 3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.hackingwithswift.ControlRoom;
 				PRODUCT_NAME = "Control Room";
+				SUPPORTED_PLATFORMS = "macosx xros xrsimulator";
+				SUPPORTS_MACCATALYST = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 7;
 			};
 			name = Debug;
 		};
@@ -890,7 +897,10 @@
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.hackingwithswift.ControlRoom;
 				PRODUCT_NAME = "Control Room";
+				SUPPORTED_PLATFORMS = "macosx xros xrsimulator";
+				SUPPORTS_MACCATALYST = NO;
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 7;
 			};
 			name = Release;
 		};

--- a/ControlRoom.xcodeproj/project.pbxproj
+++ b/ControlRoom.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		3C13FF952BEF499400060A5C /* NotificationsFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C13FF942BEF499400060A5C /* NotificationsFormView.swift */; };
 		3C13FF972BEF4AAE00060A5C /* PickersFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C13FF962BEF4AAE00060A5C /* PickersFormView.swift */; };
 		3C13FF992BEF4C9200060A5C /* ColorPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C13FF982BEF4C9200060A5C /* ColorPickerView.swift */; };
+		3C13FF9B2BEF4D5100060A5C /* PathToTerminalTextFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C13FF9A2BEF4D5100060A5C /* PathToTerminalTextFieldView.swift */; };
 		3CF07C312BEF48D200770363 /* TogglesFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CF07C302BEF48D200770363 /* TogglesFormView.swift */; };
 		41C44ACD2616FCB50016B1E4 /* FFMPEGConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41C44ACC2616FCB50016B1E4 /* FFMPEGConverter.swift */; };
 		510871F225C317830009E39F /* SimulatorAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510871F125C317830009E39F /* SimulatorAction.swift */; };
@@ -102,6 +103,7 @@
 		3C13FF942BEF499400060A5C /* NotificationsFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsFormView.swift; sourceTree = "<group>"; };
 		3C13FF962BEF4AAE00060A5C /* PickersFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PickersFormView.swift; sourceTree = "<group>"; };
 		3C13FF982BEF4C9200060A5C /* ColorPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorPickerView.swift; sourceTree = "<group>"; };
+		3C13FF9A2BEF4D5100060A5C /* PathToTerminalTextFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathToTerminalTextFieldView.swift; sourceTree = "<group>"; };
 		3CF07C302BEF48D200770363 /* TogglesFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TogglesFormView.swift; sourceTree = "<group>"; };
 		41C44ACC2616FCB50016B1E4 /* FFMPEGConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FFMPEGConverter.swift; sourceTree = "<group>"; };
 		510871F125C317830009E39F /* SimulatorAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulatorAction.swift; sourceTree = "<group>"; };
@@ -430,6 +432,7 @@
 				3C13FF942BEF499400060A5C /* NotificationsFormView.swift */,
 				3C13FF962BEF4AAE00060A5C /* PickersFormView.swift */,
 				3C13FF982BEF4C9200060A5C /* ColorPickerView.swift */,
+				3C13FF9A2BEF4D5100060A5C /* PathToTerminalTextFieldView.swift */,
 			);
 			path = "Settings UI";
 			sourceTree = "<group>";
@@ -641,6 +644,7 @@
 				55AF68B723F9D2E200C5D87A /* UIState.swift in Sources */,
 				511BA59223F4031F00E3E660 /* ControlView.swift in Sources */,
 				5534158223FE0539005C0A41 /* Contributors.swift in Sources */,
+				3C13FF9B2BEF4D5100060A5C /* PathToTerminalTextFieldView.swift in Sources */,
 				511BA57F23F3FFEA00E3E660 /* MainView.swift in Sources */,
 				551F8D0023F5CB3A0006D1BD /* SimCtl+Types.swift in Sources */,
 				511BA5A023F4197200E3E660 /* StatusBarView.swift in Sources */,

--- a/ControlRoom.xcodeproj/project.pbxproj
+++ b/ControlRoom.xcodeproj/project.pbxproj
@@ -7,9 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		3C09AF722BE8B4E800C303C0 /* SettingsView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C09AF712BE8B4E800C303C0 /* SettingsView+Extension.swift */; };
 		3C13FF952BEF499400060A5C /* NotificationsFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C13FF942BEF499400060A5C /* NotificationsFormView.swift */; };
 		3C13FF972BEF4AAE00060A5C /* PickersFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C13FF962BEF4AAE00060A5C /* PickersFormView.swift */; };
+		3C13FF992BEF4C9200060A5C /* ColorPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C13FF982BEF4C9200060A5C /* ColorPickerView.swift */; };
 		3CF07C312BEF48D200770363 /* TogglesFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CF07C302BEF48D200770363 /* TogglesFormView.swift */; };
 		41C44ACD2616FCB50016B1E4 /* FFMPEGConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41C44ACC2616FCB50016B1E4 /* FFMPEGConverter.swift */; };
 		510871F225C317830009E39F /* SimulatorAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510871F125C317830009E39F /* SimulatorAction.swift */; };
@@ -99,9 +99,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		3C09AF712BE8B4E800C303C0 /* SettingsView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SettingsView+Extension.swift"; sourceTree = "<group>"; };
 		3C13FF942BEF499400060A5C /* NotificationsFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsFormView.swift; sourceTree = "<group>"; };
 		3C13FF962BEF4AAE00060A5C /* PickersFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PickersFormView.swift; sourceTree = "<group>"; };
+		3C13FF982BEF4C9200060A5C /* ColorPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorPickerView.swift; sourceTree = "<group>"; };
 		3CF07C302BEF48D200770363 /* TogglesFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TogglesFormView.swift; sourceTree = "<group>"; };
 		41C44ACC2616FCB50016B1E4 /* FFMPEGConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FFMPEGConverter.swift; sourceTree = "<group>"; };
 		510871F125C317830009E39F /* SimulatorAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulatorAction.swift; sourceTree = "<group>"; };
@@ -426,10 +426,10 @@
 			isa = PBXGroup;
 			children = (
 				55AF68B423F9CFD600C5D87A /* SettingsView.swift */,
-				3C09AF712BE8B4E800C303C0 /* SettingsView+Extension.swift */,
 				3CF07C302BEF48D200770363 /* TogglesFormView.swift */,
 				3C13FF942BEF499400060A5C /* NotificationsFormView.swift */,
 				3C13FF962BEF4AAE00060A5C /* PickersFormView.swift */,
+				3C13FF982BEF4C9200060A5C /* ColorPickerView.swift */,
 			);
 			path = "Settings UI";
 			sourceTree = "<group>";
@@ -649,13 +649,13 @@
 				3C13FF952BEF499400060A5C /* NotificationsFormView.swift in Sources */,
 				51AB56E92A141055002B5A67 /* ColorsView.swift in Sources */,
 				51B0242325C3106E0042394E /* AppSummaryView.swift in Sources */,
+				3C13FF992BEF4C9200060A5C /* ColorPickerView.swift in Sources */,
 				51AB56ED2A143B90002B5A67 /* Double-Rounding.swift in Sources */,
 				55DF68BB23F8BE8D00E717D3 /* CreateSimulatorActionSheet.swift in Sources */,
 				515E56DF2A14499B003B4F5A /* XcodeColorSet.swift in Sources */,
 				551F8CF923F4C45A0006D1BD /* SimulatorSidebarView.swift in Sources */,
 				54C2092827DBDB6F00E47016 /* DocumentPicker.swift in Sources */,
 				51203A512A09588A00CBE517 /* Capture.swift in Sources */,
-				3C09AF722BE8B4E800C303C0 /* SettingsView+Extension.swift in Sources */,
 				511BA59C23F4172400E3E660 /* SystemView.swift in Sources */,
 				54C2092D27DBDE7500E47016 /* UTType+Extension.swift in Sources */,
 				511BA57D23F3FFEA00E3E660 /* ControlRoomApp.swift in Sources */,

--- a/ControlRoom.xcodeproj/project.pbxproj
+++ b/ControlRoom.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		3C09AF722BE8B4E800C303C0 /* SettingsView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C09AF712BE8B4E800C303C0 /* SettingsView+Extension.swift */; };
+		3C13FF952BEF499400060A5C /* NotificationsFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C13FF942BEF499400060A5C /* NotificationsFormView.swift */; };
+		3CF07C312BEF48D200770363 /* TogglesFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CF07C302BEF48D200770363 /* TogglesFormView.swift */; };
 		41C44ACD2616FCB50016B1E4 /* FFMPEGConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41C44ACC2616FCB50016B1E4 /* FFMPEGConverter.swift */; };
 		510871F225C317830009E39F /* SimulatorAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510871F125C317830009E39F /* SimulatorAction.swift */; };
 		511BA57D23F3FFEA00E3E660 /* ControlRoomApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511BA57C23F3FFEA00E3E660 /* ControlRoomApp.swift */; };
@@ -97,6 +99,8 @@
 
 /* Begin PBXFileReference section */
 		3C09AF712BE8B4E800C303C0 /* SettingsView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SettingsView+Extension.swift"; sourceTree = "<group>"; };
+		3C13FF942BEF499400060A5C /* NotificationsFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsFormView.swift; sourceTree = "<group>"; };
+		3CF07C302BEF48D200770363 /* TogglesFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TogglesFormView.swift; sourceTree = "<group>"; };
 		41C44ACC2616FCB50016B1E4 /* FFMPEGConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FFMPEGConverter.swift; sourceTree = "<group>"; };
 		510871F125C317830009E39F /* SimulatorAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulatorAction.swift; sourceTree = "<group>"; };
 		511BA57923F3FFEA00E3E660 /* Control Room.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Control Room.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -421,6 +425,8 @@
 			children = (
 				55AF68B423F9CFD600C5D87A /* SettingsView.swift */,
 				3C09AF712BE8B4E800C303C0 /* SettingsView+Extension.swift */,
+				3CF07C302BEF48D200770363 /* TogglesFormView.swift */,
+				3C13FF942BEF499400060A5C /* NotificationsFormView.swift */,
 			);
 			path = "Settings UI";
 			sourceTree = "<group>";
@@ -637,6 +643,7 @@
 				511BA5A023F4197200E3E660 /* StatusBarView.swift in Sources */,
 				51AB56EB2A141C57002B5A67 /* ColorHistoryController.swift in Sources */,
 				ACDF076823F7E91A00597B3B /* ApplicationType.swift in Sources */,
+				3C13FF952BEF499400060A5C /* NotificationsFormView.swift in Sources */,
 				51AB56E92A141055002B5A67 /* ColorsView.swift in Sources */,
 				51B0242325C3106E0042394E /* AppSummaryView.swift in Sources */,
 				51AB56ED2A143B90002B5A67 /* Double-Rounding.swift in Sources */,
@@ -675,6 +682,7 @@
 				51B0241625C30EEF0042394E /* CLLocationCoordinate2D-Identifiable.swift in Sources */,
 				5534157E23FE04FA005C0A41 /* AboutView.swift in Sources */,
 				511BA59023F4030D00E3E660 /* LoadingView.swift in Sources */,
+				3CF07C312BEF48D200770363 /* TogglesFormView.swift in Sources */,
 				511BA59623F408F800E3E660 /* LoadingFailedView.swift in Sources */,
 				510871F225C317830009E39F /* SimulatorAction.swift in Sources */,
 				55AF68B523F9CFD600C5D87A /* SettingsView.swift in Sources */,

--- a/ControlRoom.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ControlRoom.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "69c39523ac0471922b625cc56b8722155cfd2afd660bdd4f5ff67335b5b87714",
   "pins" : [
     {
       "identity" : "keyboardshortcuts",
@@ -10,5 +11,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/ControlRoom/Settings UI/ColorPickerView.swift
+++ b/ControlRoom/Settings UI/ColorPickerView.swift
@@ -1,18 +1,21 @@
 //
-//  SettingsView+Extension.swift
+//  ColorPickerView.swift
 //  ControlRoom
 //
-//  Created by Elliot Knight on 06/05/2024.
+//  Created by Elliot Knight on 11/05/2024.
 //  Copyright © 2024 Paul Hudson. All rights reserved.
 //
 
 import SwiftUI
-import KeyboardShortcuts
 
-// MARK: - Extracted Views
+struct ColorPickerView: View {
+    /// Whether hex strings should be printed in uppercase or not.
+    @AppStorage("CRColorPickerUppercaseHex") var uppercaseHex = true
 
-extension SettingsView {
-    func makeColorPicker() -> some View {
+    /// How many decimal places to use for rounding picked colors.
+    @AppStorage("CRColorPickerAccuracy") var colorPickerAccuracy = 2
+    
+    var body: some View {
         VStack {
             Toggle("Uppercase Hex Strings", isOn: $uppercaseHex)
                 .padding(.bottom)
@@ -22,4 +25,8 @@ extension SettingsView {
                 .pickerStyle(.segmented)
         }
     }
+}
+
+#Preview {
+    ColorPickerView()
 }

--- a/ControlRoom/Settings UI/ColorPickerView.swift
+++ b/ControlRoom/Settings UI/ColorPickerView.swift
@@ -14,7 +14,7 @@ struct ColorPickerView: View {
 
     /// How many decimal places to use for rounding picked colors.
     @AppStorage("CRColorPickerAccuracy") var colorPickerAccuracy = 2
-    
+
     var body: some View {
         VStack {
             Toggle("Uppercase Hex Strings", isOn: $uppercaseHex)

--- a/ControlRoom/Settings UI/NotificationsFormView.swift
+++ b/ControlRoom/Settings UI/NotificationsFormView.swift
@@ -1,0 +1,31 @@
+//
+//  NotificationsFormView.swift
+//  ControlRoom
+//
+//  Created by Elliot Knight on 11/05/2024.
+//  Copyright © 2024 Paul Hudson. All rights reserved.
+//
+
+import SwiftUI
+import KeyboardShortcuts
+
+struct NotificationsFormView: View {
+    var body: some View {
+        Form {
+            makeKeyboardShortcut(title: "Resend last push notification", for: .resendLastPushNotification)
+            makeKeyboardShortcut(title: "Restart last selected app", for: .restartLastSelectedApp)
+            makeKeyboardShortcut(title: "Reopen last URL", for: .reopenLastURL)
+        }
+    }
+
+    private func makeKeyboardShortcut(title: String, for name: KeyboardShortcuts.Name) -> some View {
+        HStack {
+            Text(title)
+            KeyboardShortcuts.Recorder(for: name)
+        }
+    }
+}
+
+#Preview {
+    NotificationsFormView()
+}

--- a/ControlRoom/Settings UI/PathToTerminalTextFieldView.swift
+++ b/ControlRoom/Settings UI/PathToTerminalTextFieldView.swift
@@ -1,0 +1,28 @@
+//
+//  PathToTerminalTextFieldView.swift
+//  ControlRoom
+//
+//  Created by Elliot Knight on 11/05/2024.
+//  Copyright © 2024 Paul Hudson. All rights reserved.
+//
+
+import SwiftUI
+
+struct PathToTerminalTextFieldView: View {
+    @EnvironmentObject var preferences: Preferences
+
+    var body: some View {
+        Form {
+            TextField(
+                "Path to Terminal",
+                text: $preferences.terminalAppPath
+            )
+            .textFieldStyle(.roundedBorder)
+        }
+    }
+}
+
+#Preview {
+    PathToTerminalTextFieldView()
+        .environmentObject(Preferences())
+}

--- a/ControlRoom/Settings UI/PickersFormView.swift
+++ b/ControlRoom/Settings UI/PickersFormView.swift
@@ -1,0 +1,69 @@
+//
+//  PickersFormView.swift
+//  ControlRoom
+//
+//  Created by Elliot Knight on 11/05/2024.
+//  Copyright © 2024 Paul Hudson. All rights reserved.
+//
+
+import SwiftUI
+
+struct PickersFormView: View {
+    /// The user's settings for capturing
+    @AppStorage("captureSettings") var captureSettings = CaptureSettings(imageFormat: .png, videoFormat: .h264, display: .internal, mask: .ignored)
+
+    /// Whether the user wants us to render device bezels around their screenshots.
+    /// Note: this requires a mask of alpha, so we enforce that when true.
+    @AppStorage("renderChrome") var renderChrome = false
+
+    var body: some View {
+        Form {
+            Picker("Screenshot Format:", selection: $captureSettings.imageFormat) {
+                ForEach(SimCtl.IO.ImageFormat.allCases, id: \.self) { type in
+                    Text(type.rawValue.uppercased()).tag(type)
+                }
+            }
+
+            Picker("Video Format:", selection: $captureSettings.videoFormat) {
+                ForEach(SimCtl.IO.VideoFormat.all, id: \.self) { item in
+                    if item == .divider {
+                        Divider()
+                    } else {
+                        Text(item.name).tag(item)
+                    }
+                }
+            }
+
+            Picker("Display:", selection: $captureSettings.display) {
+                ForEach(SimCtl.IO.Display.allCases, id: \.self) { display in
+                    Text(display.rawValue.capitalized).tag(display)
+                }
+            }
+
+            Picker("Mask:", selection: $captureSettings.mask) {
+                ForEach(SimCtl.IO.Mask.allCases, id: \.self) { mask in
+                    Text(mask.rawValue.capitalized).tag(mask)
+                }
+            }
+            .disabled(renderChrome)
+
+            Toggle(isOn: $renderChrome.onChange(updateChromeSettings)) {
+                VStack(alignment: .leading) {
+                    Text("Add device chrome to screenshots")
+                    Text("This is an experimental feature and may not function properly yet.")
+                        .font(.caption)
+                }
+            }
+        }
+    }
+    
+    private func updateChromeSettings() {
+        if renderChrome {
+            captureSettings.mask = .alpha
+        }
+    }
+}
+
+#Preview {
+    PickersFormView()
+}

--- a/ControlRoom/Settings UI/SettingsView+Extension.swift
+++ b/ControlRoom/Settings UI/SettingsView+Extension.swift
@@ -12,47 +12,6 @@ import KeyboardShortcuts
 // MARK: - Extracted Views
 
 extension SettingsView {
-    func makePickersForm() -> some View {
-        Form {
-            Picker("Screenshot Format:", selection: $captureSettings.imageFormat) {
-                ForEach(SimCtl.IO.ImageFormat.allCases, id: \.self) { type in
-                    Text(type.rawValue.uppercased()).tag(type)
-                }
-            }
-
-            Picker("Video Format:", selection: $captureSettings.videoFormat) {
-                ForEach(SimCtl.IO.VideoFormat.all, id: \.self) { item in
-                    if item == .divider {
-                        Divider()
-                    } else {
-                        Text(item.name).tag(item)
-                    }
-                }
-            }
-
-            Picker("Display:", selection: $captureSettings.display) {
-                ForEach(SimCtl.IO.Display.allCases, id: \.self) { display in
-                    Text(display.rawValue.capitalized).tag(display)
-                }
-            }
-
-            Picker("Mask:", selection: $captureSettings.mask) {
-                ForEach(SimCtl.IO.Mask.allCases, id: \.self) { mask in
-                    Text(mask.rawValue.capitalized).tag(mask)
-                }
-            }
-            .disabled(renderChrome)
-
-            Toggle(isOn: $renderChrome.onChange(updateChromeSettings)) {
-                VStack(alignment: .leading) {
-                    Text("Add device chrome to screenshots")
-                    Text("This is an experimental feature and may not function properly yet.")
-                        .font(.caption)
-                }
-            }
-        }
-    }
-
     func makeColorPicker() -> some View {
         VStack {
             Toggle("Uppercase Hex Strings", isOn: $uppercaseHex)

--- a/ControlRoom/Settings UI/SettingsView+Extension.swift
+++ b/ControlRoom/Settings UI/SettingsView+Extension.swift
@@ -12,34 +12,6 @@ import KeyboardShortcuts
 // MARK: - Extracted Views
 
 extension SettingsView {
-    func makeTogglesForm() -> some View {
-        Form {
-            Toggle("Keep window on top", isOn: $preferences.wantsFloatingWindow)
-            Toggle("Show Default simulator", isOn: $preferences.showDefaultSimulator)
-            Toggle("Show booted devices first", isOn: $preferences.showBootedDevicesFirst)
-            Toggle("Show icon in menu bar", isOn: $preferences.wantsMenuBarIcon)
-        }
-    }
-
-    func makeNotificationsForm() -> some View {
-        Form {
-            HStack {
-                Text("Resend last push notification")
-                KeyboardShortcuts.Recorder(for: .resendLastPushNotification)
-            }
-
-            HStack {
-                Text("Restart last selected app")
-                KeyboardShortcuts.Recorder(for: .restartLastSelectedApp)
-            }
-
-            HStack {
-                Text("Reopen last URL")
-                KeyboardShortcuts.Recorder(for: .reopenLastURL)
-            }
-        }
-    }
-
     func makePickersForm() -> some View {
         Form {
             Picker("Screenshot Format:", selection: $captureSettings.imageFormat) {

--- a/ControlRoom/Settings UI/SettingsView+Extension.swift
+++ b/ControlRoom/Settings UI/SettingsView+Extension.swift
@@ -1,0 +1,94 @@
+//
+//  SettingsView+Extension.swift
+//  ControlRoom
+//
+//  Created by Elliot Knight on 06/05/2024.
+//  Copyright © 2024 Paul Hudson. All rights reserved.
+//
+
+import SwiftUI
+import KeyboardShortcuts
+
+// MARK: - Extracted Views
+
+extension SettingsView {
+    func makeTogglesForm() -> some View {
+        Form {
+            Toggle("Keep window on top", isOn: $preferences.wantsFloatingWindow)
+            Toggle("Show Default simulator", isOn: $preferences.showDefaultSimulator)
+            Toggle("Show booted devices first", isOn: $preferences.showBootedDevicesFirst)
+            Toggle("Show icon in menu bar", isOn: $preferences.wantsMenuBarIcon)
+        }
+    }
+
+    func makeNotificationsForm() -> some View {
+        Form {
+            HStack {
+                Text("Resend last push notification")
+                KeyboardShortcuts.Recorder(for: .resendLastPushNotification)
+            }
+
+            HStack {
+                Text("Restart last selected app")
+                KeyboardShortcuts.Recorder(for: .restartLastSelectedApp)
+            }
+
+            HStack {
+                Text("Reopen last URL")
+                KeyboardShortcuts.Recorder(for: .reopenLastURL)
+            }
+        }
+    }
+
+    func makePickersForm() -> some View {
+        Form {
+            Picker("Screenshot Format:", selection: $captureSettings.imageFormat) {
+                ForEach(SimCtl.IO.ImageFormat.allCases, id: \.self) { type in
+                    Text(type.rawValue.uppercased()).tag(type)
+                }
+            }
+
+            Picker("Video Format:", selection: $captureSettings.videoFormat) {
+                ForEach(SimCtl.IO.VideoFormat.all, id: \.self) { item in
+                    if item == .divider {
+                        Divider()
+                    } else {
+                        Text(item.name).tag(item)
+                    }
+                }
+            }
+
+            Picker("Display:", selection: $captureSettings.display) {
+                ForEach(SimCtl.IO.Display.allCases, id: \.self) { display in
+                    Text(display.rawValue.capitalized).tag(display)
+                }
+            }
+
+            Picker("Mask:", selection: $captureSettings.mask) {
+                ForEach(SimCtl.IO.Mask.allCases, id: \.self) { mask in
+                    Text(mask.rawValue.capitalized).tag(mask)
+                }
+            }
+            .disabled(renderChrome)
+
+            Toggle(isOn: $renderChrome.onChange(updateChromeSettings)) {
+                VStack(alignment: .leading) {
+                    Text("Add device chrome to screenshots")
+                    Text("This is an experimental feature and may not function properly yet.")
+                        .font(.caption)
+                }
+            }
+        }
+    }
+
+    func makeColorPicker() -> some View {
+        VStack {
+            Toggle("Uppercase Hex Strings", isOn: $uppercaseHex)
+                .padding(.bottom)
+
+            Text("Set the maximum number of decimal places to use when generating code for picked simulator colors. The default is 2.")
+            Stepper("Decimal Places: \(colorPickerAccuracy)", value: $colorPickerAccuracy, in: 0...5)
+                .pickerStyle(.segmented)
+        }
+    }
+}

--- a/ControlRoom/Settings UI/SettingsView.swift
+++ b/ControlRoom/Settings UI/SettingsView.swift
@@ -28,13 +28,13 @@ struct SettingsView: View {
 
     var body: some View {
         TabView {
-            makeTogglesForm()
+            TogglesFormView()
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .tabItem {
                     Label("Window", systemImage: "macwindow")
                 }
 
-            makeNotificationsForm()
+            NotificationsFormView()
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .tabItem {
                     Label("Shortcuts", systemImage: "keyboard")

--- a/ControlRoom/Settings UI/SettingsView.swift
+++ b/ControlRoom/Settings UI/SettingsView.swift
@@ -28,94 +28,30 @@ struct SettingsView: View {
 
     var body: some View {
         TabView {
-            Form {
-                Toggle("Keep window on top", isOn: $preferences.wantsFloatingWindow)
-                Toggle("Show Default simulator", isOn: $preferences.showDefaultSimulator)
-                Toggle("Show booted devices first", isOn: $preferences.showBootedDevicesFirst)
-                Toggle("Show icon in menu bar", isOn: $preferences.wantsMenuBarIcon)
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .tabItem {
-                Label("Window", systemImage: "macwindow")
-            }
-
-            Form {
-                HStack {
-                    Text("Resend last push notification")
-                    KeyboardShortcuts.Recorder(for: .resendLastPushNotification)
+            makeTogglesForm()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .tabItem {
+                    Label("Window", systemImage: "macwindow")
                 }
 
-                HStack {
-                    Text("Restart last selected app")
-                    KeyboardShortcuts.Recorder(for: .restartLastSelectedApp)
+            makeNotificationsForm()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .tabItem {
+                    Label("Shortcuts", systemImage: "keyboard")
                 }
 
-                HStack {
-                    Text("Reopen last URL")
-                    KeyboardShortcuts.Recorder(for: .reopenLastURL)
-                }
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .tabItem {
-                Label("Shortcuts", systemImage: "keyboard")
-            }
-
-            Form {
-                Picker("Screenshot Format:", selection: $captureSettings.imageFormat) {
-                    ForEach(SimCtl.IO.ImageFormat.allCases, id: \.self) { type in
-                        Text(type.rawValue.uppercased()).tag(type)
-                    }
+            makePickersForm()
+                .padding()
+                .tabItem {
+                    Label("Screenshots", systemImage: "camera.on.rectangle")
                 }
 
-                Picker("Video Format:", selection: $captureSettings.videoFormat) {
-                    ForEach(SimCtl.IO.VideoFormat.all, id: \.self) { item in
-                        if item == .divider {
-                            Divider()
-                        } else {
-                            Text(item.name).tag(item)
-                        }
-                    }
+            makeColorPicker()
+                .padding()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .tabItem {
+                    Label("Colors", systemImage: "paintpalette")
                 }
-
-                Picker("Display:", selection: $captureSettings.display) {
-                    ForEach(SimCtl.IO.Display.allCases, id: \.self) { display in
-                        Text(display.rawValue.capitalized).tag(display)
-                    }
-                }
-
-                Picker("Mask:", selection: $captureSettings.mask) {
-                    ForEach(SimCtl.IO.Mask.allCases, id: \.self) { mask in
-                        Text(mask.rawValue.capitalized).tag(mask)
-                    }
-                }
-                .disabled(renderChrome)
-
-                Toggle(isOn: $renderChrome.onChange(updateChromeSettings)) {
-                    VStack(alignment: .leading) {
-                        Text("Add device chrome to screenshots")
-                        Text("This is an experimental feature and may not function properly yet.")
-                            .font(.caption)
-                    }
-                }
-            }
-            .padding()
-            .tabItem {
-                Label("Screenshots", systemImage: "camera.on.rectangle")
-            }
-
-            VStack {
-                Toggle("Uppercase Hex Strings", isOn: $uppercaseHex)
-                    .padding(.bottom)
-
-                Text("Set the maximum number of decimal places to use when generating code for picked simulator colors. The default is 2.")
-                Stepper("Decimal Places: \(colorPickerAccuracy)", value: $colorPickerAccuracy, in: 0...5)
-                    .pickerStyle(.segmented)
-            }
-            .padding()
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .tabItem {
-                Label("Colors", systemImage: "paintpalette")
-            }
 
             Form {
                 TextField(

--- a/ControlRoom/Settings UI/SettingsView.swift
+++ b/ControlRoom/Settings UI/SettingsView.swift
@@ -13,13 +13,6 @@ struct SettingsView: View {
     @EnvironmentObject var preferences: Preferences
     @Environment(\.presentationMode) var presentationMode
 
-    /// The user's settings for capturing
-    @AppStorage("captureSettings") var captureSettings = CaptureSettings(imageFormat: .png, videoFormat: .h264, display: .internal, mask: .ignored)
-
-    /// Whether the user wants us to render device bezels around their screenshots.
-    /// Note: this requires a mask of alpha, so we enforce that when true.
-    @AppStorage("renderChrome") var renderChrome = false
-
     /// How many decimal places to use for rounding picked colors.
     @AppStorage("CRColorPickerAccuracy") var colorPickerAccuracy = 2
 
@@ -40,7 +33,7 @@ struct SettingsView: View {
                     Label("Shortcuts", systemImage: "keyboard")
                 }
 
-            makePickersForm()
+            PickersFormView()
                 .padding()
                 .tabItem {
                     Label("Screenshots", systemImage: "camera.on.rectangle")
@@ -67,12 +60,6 @@ struct SettingsView: View {
             }
         }
         .frame(minWidth: 550)
-    }
-
-    func updateChromeSettings() {
-        if renderChrome {
-            captureSettings.mask = .alpha
-        }
     }
 }
 

--- a/ControlRoom/Settings UI/SettingsView.swift
+++ b/ControlRoom/Settings UI/SettingsView.swift
@@ -10,9 +10,6 @@ import KeyboardShortcuts
 import SwiftUI
 
 struct SettingsView: View {
-    @EnvironmentObject var preferences: Preferences
-    @Environment(\.presentationMode) var presentationMode
-
     var body: some View {
         TabView {
             TogglesFormView()

--- a/ControlRoom/Settings UI/SettingsView.swift
+++ b/ControlRoom/Settings UI/SettingsView.swift
@@ -40,18 +40,12 @@ struct SettingsView: View {
                     Label("Colors", systemImage: "paintpalette")
                 }
 
-            Form {
-                TextField(
-                    "Path to Terminal",
-                    text: $preferences.terminalAppPath
-                )
-                .textFieldStyle(.roundedBorder)
-            }
-            .padding()
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .tabItem {
-                Label("Locations", systemImage: "externaldrive")
-            }
+            PathToTerminalTextFieldView()
+                .padding()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .tabItem {
+                    Label("Locations", systemImage: "externaldrive")
+                }
         }
         .frame(minWidth: 550)
     }

--- a/ControlRoom/Settings UI/SettingsView.swift
+++ b/ControlRoom/Settings UI/SettingsView.swift
@@ -13,12 +13,6 @@ struct SettingsView: View {
     @EnvironmentObject var preferences: Preferences
     @Environment(\.presentationMode) var presentationMode
 
-    /// How many decimal places to use for rounding picked colors.
-    @AppStorage("CRColorPickerAccuracy") var colorPickerAccuracy = 2
-
-    /// Whether hex strings should be printed in uppercase or not.
-    @AppStorage("CRColorPickerUppercaseHex") var uppercaseHex = true
-
     var body: some View {
         TabView {
             TogglesFormView()
@@ -39,7 +33,7 @@ struct SettingsView: View {
                     Label("Screenshots", systemImage: "camera.on.rectangle")
                 }
 
-            makeColorPicker()
+            ColorPickerView()
                 .padding()
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .tabItem {

--- a/ControlRoom/Settings UI/SettingsView.swift
+++ b/ControlRoom/Settings UI/SettingsView.swift
@@ -16,12 +16,14 @@ struct SettingsView: View {
     var body: some View {
         TabView {
             TogglesFormView()
+                .padding()
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .tabItem {
                     Label("Window", systemImage: "macwindow")
                 }
 
             NotificationsFormView()
+                .padding()
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .tabItem {
                     Label("Shortcuts", systemImage: "keyboard")
@@ -29,6 +31,7 @@ struct SettingsView: View {
 
             PickersFormView()
                 .padding()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .tabItem {
                     Label("Screenshots", systemImage: "camera.on.rectangle")
                 }
@@ -51,9 +54,7 @@ struct SettingsView: View {
     }
 }
 
-struct PreferencesView_Previews: PreviewProvider {
-    static var previews: some View {
-        SettingsView()
-            .environmentObject(Preferences())
-    }
+#Preview {
+    SettingsView()
+        .environmentObject(Preferences())
 }

--- a/ControlRoom/Settings UI/TogglesFormView.swift
+++ b/ControlRoom/Settings UI/TogglesFormView.swift
@@ -1,0 +1,26 @@
+//
+//  TogglesFormView.swift
+//  ControlRoom
+//
+//  Created by Elliot Knight on 11/05/2024.
+//  Copyright © 2024 Paul Hudson. All rights reserved.
+//
+
+import SwiftUI
+
+struct TogglesFormView: View {
+    @EnvironmentObject private var preferences: Preferences
+    var body: some View {
+        Form {
+            Toggle("Keep window on top", isOn: $preferences.wantsFloatingWindow)
+            Toggle("Show Default simulator", isOn: $preferences.showDefaultSimulator)
+            Toggle("Show booted devices first", isOn: $preferences.showBootedDevicesFirst)
+            Toggle("Show icon in menu bar", isOn: $preferences.wantsMenuBarIcon)
+        }
+    }
+}
+
+#Preview {
+    TogglesFormView()
+        .environmentObject(Preferences())
+}


### PR DESCRIPTION
I found that settings view was really big, so I decided to extract them on method returning `some View` for a better readability.

If you have any feedback do not hesitate to reach me or comment the PR.

I think we can have a better naming for methods but I am not much inspired now 