### PR TITLE
Workaround: Only set status bar time

### DIFF
--- a/ControlRoom/Controllers/SimCtl.swift
+++ b/ControlRoom/Controllers/SimCtl.swift
@@ -105,7 +105,12 @@ enum SimCtl: CommandLineCommandExecuter {
     }
 
     static func overrideStatusBarTime(_ simulator: String, time: Date) {
-        let timeString = ISO8601DateFormatter().string(from: time)
+        // Use only time for now since ISO8601 parsing is broken since Xcode 15.3
+        // https://stackoverflow.com/a/59071895
+        // let timeString = ISO8601DateFormatter().string(from: time)
+        let timeOnlyFormatter = DateFormatter()
+        timeOnlyFormatter.dateFormat = "hh:mm"
+        let timeString = timeOnlyFormatter.string(from: time)
         execute(.statusBar(deviceId: simulator, operation: .override([.time(timeString)])))
     }
     static func setAppearance(_ simulator: String, appearance: UI.Appearance) {


### PR DESCRIPTION
Since Xcode 15.3 `simctl` has failed to parse the ISO8601 string that is sent when changing the status bar time and spits out the error below:
```
An error was encountered processing the command (domain=NSPOSIXErrorDomain, code=22):
Simulator device failed to complete the requested operation.
Invalid argument
Underlying error (domain=NSPOSIXErrorDomain, code=22):
	Invalid, non-ISO date/time string
	Invalid argument
```

However it only fails to parse the string when it contains a day, month and year and not when it's only hours and minutes.
To continue to be able to use the functionality of setting just the time (seeing as its often the most used between a date and a time of day) I have disabled that for now so that we may re-introduce the `ISO8601DateFormatter` some time in the future.