### PR TITLE
Add Edit functionality for deep links

### DIFF
--- a/ControlRoom/Controllers/DeepLinksController.swift
+++ b/ControlRoom/Controllers/DeepLinksController.swift
@@ -46,6 +46,29 @@ class DeepLinksController: ObservableObject {
             save()
         }
     }
+    
+    /// Updates an existing DeepLink with the new name and URL. No changes are made if the `itemID` is `nil`, a matching
+    /// DeepLink cannot be found or if the new stringified URL fails construction as a `URL`.
+    /// - Parameters:
+    ///   - itemID: The identifier of the link that needs to be updated.
+    ///   - name: The updated name for this link.
+    ///   - url: The updated stringified URL for the deep link.
+    func edit(_ itemID: DeepLink.ID?, name: String, url: String) {
+        guard
+            let itemID,
+            let index = links.firstIndex(where: { $0.id == itemID }),
+            let verifiedURL = URL(string: url)
+        else {
+            return
+        }
+        
+        var link = links[index]
+        link.name = name
+        link.url = verifiedURL
+        links[index] = link
+        
+        save()
+    }
 
     /// Deletes a DeepLink instance based on its ID.
     /// - Parameter itemID: The identifier of the link we want to delete.
@@ -65,5 +88,15 @@ class DeepLinksController: ObservableObject {
     func sort(using comparator: [KeyPathComparator<DeepLink>]) {
         links.sort(using: comparator)
         save()
+    }
+    
+    /// Finds the first deep link matching the desired DeepLink.ID
+    /// - Parameter itemID: The identifier to search for.
+    /// - Returns: The first matching DeepLink if one is found. Returns `nil` if no matching link is found or if
+    /// `itemID` parameter is `nil`.
+    func link(_ itemID: DeepLink.ID?) -> DeepLink? {
+        guard let itemID else { return nil }
+        
+        return links.first(where: { $0.id == itemID })
     }
 }

--- a/ControlRoom/Simulator UI/ControlScreens/SystemView/DeepLinkEditorView.swift
+++ b/ControlRoom/Simulator UI/ControlScreens/SystemView/DeepLinkEditorView.swift
@@ -46,6 +46,11 @@ struct DeepLinkEditorView: View {
                     TableColumn("Name", value: \.name)
                     TableColumn("URL", value: \.url.absoluteString)
                 }
+                .contextMenu(forSelectionType: DeepLink.ID.self) { _ in
+                    
+                } primaryAction: { _ in
+                    showingEditSheet.toggle()
+                }
             }
 
             HStack {

--- a/ControlRoom/Simulator UI/ControlScreens/SystemView/DeepLinkEditorView.swift
+++ b/ControlRoom/Simulator UI/ControlScreens/SystemView/DeepLinkEditorView.swift
@@ -123,11 +123,13 @@ private extension DeepLinkEditorView {
                     Button("Cancel", role: .cancel) {
                         dismiss()
                     }
+                    .keyboardShortcut(.escape)
                     
                     Button("Save") {
                         deepLinks.edit(deepLink, name: name, url: url)
                         dismiss()
                     }
+                    .keyboardShortcut(.return)
                 }
             }
             .onAppear {

--- a/ControlRoom/Simulator UI/ControlScreens/SystemView/DeepLinkEditorView.swift
+++ b/ControlRoom/Simulator UI/ControlScreens/SystemView/DeepLinkEditorView.swift
@@ -123,12 +123,14 @@ private extension DeepLinkEditorView {
                     Button("Cancel", role: .cancel) {
                         dismiss()
                     }
+                    .focusable()
                     .keyboardShortcut(.escape)
                     
                     Button("Save") {
                         deepLinks.edit(deepLink, name: name, url: url)
                         dismiss()
                     }
+                    .focusable()
                     .keyboardShortcut(.return)
                 }
             }

--- a/ControlRoom/Simulator UI/ControlScreens/SystemView/DeepLinkEditorView.swift
+++ b/ControlRoom/Simulator UI/ControlScreens/SystemView/DeepLinkEditorView.swift
@@ -58,6 +58,11 @@ struct DeepLinkEditorView: View {
                 }
                 .disabled(selection == nil)
                 
+                Button("Duplicate") {
+                    duplicateSelected()
+                }
+                .disabled(selection == nil)
+                
                 Button("Delete") {
                     deleteSelected()
                 }
@@ -97,6 +102,12 @@ struct DeepLinkEditorView: View {
     func deleteSelected() {
         deepLinks.delete(selection)
         selection = nil
+    }
+    
+    func duplicateSelected() {
+        if let link = deepLinks.link(selection) {
+            deepLinks.create(name: link.name + " (copy)", url: link.url.absoluteString)
+        }
     }
 }
 


### PR DESCRIPTION
This PR adds the ability to Edit an existing deep link. 
As a bonus feature I've also added the ability to duplicate a deep link, to make it easier and faster to build out the collection of deep links.

As part of this work I've added support for double clicking on a deep link to launch edit mode for it.

The edit view is presented using the Sheet mechanic rather than Alert. During my testing I found that using the Alert mode just made the new window really narrow, making it hard to edit the deep link.

When duplicating a selected deep link, the newly duplicated deep link's name gets the suffix of ` (copy)` added to it in order to make it easily identifiable.

| New Buttons | Duplicated Deep Link | Deep Link Edit View |
|--------|--------|--------|
| ![All new buttons](https://github.com/user-attachments/assets/87f0687b-0f8d-4d4a-bce9-a55f8a803521) | ![Duplicated](https://github.com/user-attachments/assets/2a0f4a2e-1d1c-45ac-850f-00783c1b588a) | ![Edit](https://github.com/user-attachments/assets/c87d05d7-4ce4-4914-b71b-ffde46a42889) | 