### PR TITLE
New feature: Simulator Snapshots

### DIFF
--- a/ControlRoom.xcodeproj/project.pbxproj
+++ b/ControlRoom.xcodeproj/project.pbxproj
@@ -13,6 +13,12 @@
 		3C13FF9B2BEF4D5100060A5C /* PathToTerminalTextFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C13FF9A2BEF4D5100060A5C /* PathToTerminalTextFieldView.swift */; };
 		3CF07C312BEF48D200770363 /* TogglesFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CF07C302BEF48D200770363 /* TogglesFormView.swift */; };
 		41C44ACD2616FCB50016B1E4 /* FFMPEGConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41C44ACC2616FCB50016B1E4 /* FFMPEGConverter.swift */; };
+		48369F9D2D0BCE7B00B74A60 /* Snapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48369F9C2D0BCE7B00B74A60 /* Snapshot.swift */; };
+		48369F9F2D0D8A9300B74A60 /* SnapshotsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48369F9E2D0D8A9300B74A60 /* SnapshotsView.swift */; };
+		4842FE542D0DFF0100DC6F82 /* SnapshotAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4842FE532D0DFEFC00DC6F82 /* SnapshotAction.swift */; };
+		48540AB12D0B4DFB004F04E4 /* SnapshotCtl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48540AB02D0B4DFB004F04E4 /* SnapshotCtl.swift */; };
+		48540AB32D0B4E0C004F04E4 /* SnapshotCtl+Commands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48540AB22D0B4E0C004F04E4 /* SnapshotCtl+Commands.swift */; };
+		488E64102D0DBFAD0022930D /* URLFileAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 488E640F2D0DBFAD0022930D /* URLFileAttribute.swift */; };
 		510871F225C317830009E39F /* SimulatorAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510871F125C317830009E39F /* SimulatorAction.swift */; };
 		511BA57D23F3FFEA00E3E660 /* ControlRoomApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511BA57C23F3FFEA00E3E660 /* ControlRoomApp.swift */; };
 		511BA57F23F3FFEA00E3E660 /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511BA57E23F3FFEA00E3E660 /* MainView.swift */; };
@@ -106,6 +112,12 @@
 		3C13FF9A2BEF4D5100060A5C /* PathToTerminalTextFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathToTerminalTextFieldView.swift; sourceTree = "<group>"; };
 		3CF07C302BEF48D200770363 /* TogglesFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TogglesFormView.swift; sourceTree = "<group>"; };
 		41C44ACC2616FCB50016B1E4 /* FFMPEGConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FFMPEGConverter.swift; sourceTree = "<group>"; };
+		48369F9C2D0BCE7B00B74A60 /* Snapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Snapshot.swift; sourceTree = "<group>"; };
+		48369F9E2D0D8A9300B74A60 /* SnapshotsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapshotsView.swift; sourceTree = "<group>"; };
+		4842FE532D0DFEFC00DC6F82 /* SnapshotAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapshotAction.swift; sourceTree = "<group>"; };
+		48540AB02D0B4DFB004F04E4 /* SnapshotCtl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapshotCtl.swift; sourceTree = "<group>"; };
+		48540AB22D0B4E0C004F04E4 /* SnapshotCtl+Commands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SnapshotCtl+Commands.swift"; sourceTree = "<group>"; };
+		488E640F2D0DBFAD0022930D /* URLFileAttribute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLFileAttribute.swift; sourceTree = "<group>"; };
 		510871F125C317830009E39F /* SimulatorAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulatorAction.swift; sourceTree = "<group>"; };
 		511BA57923F3FFEA00E3E660 /* Control Room.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Control Room.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		511BA57C23F3FFEA00E3E660 /* ControlRoomApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlRoomApp.swift; sourceTree = "<group>"; };
@@ -254,6 +266,8 @@
 		511BA5AB23F434B500E3E660 /* ControlScreens */ = {
 			isa = PBXGroup;
 			children = (
+				4842FE532D0DFEFC00DC6F82 /* SnapshotAction.swift */,
+				48369F9E2D0D8A9300B74A60 /* SnapshotsView.swift */,
 				51B0241B25C3103B0042394E /* AppView */,
 				51AB56E82A141055002B5A67 /* ColorsView.swift */,
 				C9C203EB2B17FE900081E1EF /* LocationVIew */,
@@ -288,6 +302,7 @@
 		511BA5D123F4567C00E3E660 /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
+				488E640F2D0DBFAD0022930D /* URLFileAttribute.swift */,
 				511BA5A123F41A5900E3E660 /* Binding-OnChange.swift */,
 				51203A502A09588A00CBE517 /* Capture.swift */,
 				55DF68BC23F8C76800E717D3 /* Collection.swift */,
@@ -402,6 +417,9 @@
 		555A146323F762AD00313BC5 /* Controllers */ = {
 			isa = PBXGroup;
 			children = (
+				48369F9C2D0BCE7B00B74A60 /* Snapshot.swift */,
+				48540AB02D0B4DFB004F04E4 /* SnapshotCtl.swift */,
+				48540AB22D0B4E0C004F04E4 /* SnapshotCtl+Commands.swift */,
 				ACDF076523F7D1C300597B3B /* Application.swift */,
 				ACDF076723F7E91A00597B3B /* ApplicationType.swift */,
 				51DCEFB32A0BC6B600561C9B /* CaptureController.swift */,
@@ -639,9 +657,13 @@
 				E04B47322B07B66F00DAE338 /* LocationsController.swift in Sources */,
 				54C2092B27DBDE2200E47016 /* DocumentPickerConfig.swift in Sources */,
 				ACCD798E240AE82C0004ECE5 /* PushNotification.swift in Sources */,
+				48369F9D2D0BCE7B00B74A60 /* Snapshot.swift in Sources */,
 				517928C225C47392000F6F3A /* AVAssetToGIF.swift in Sources */,
 				C9C203E62B1788C90081E1EF /* LocalSearchResult.swift in Sources */,
+				48540AB32D0B4E0C004F04E4 /* SnapshotCtl+Commands.swift in Sources */,
 				55AF68B723F9D2E200C5D87A /* UIState.swift in Sources */,
+				488E64102D0DBFAD0022930D /* URLFileAttribute.swift in Sources */,
+				48369F9F2D0D8A9300B74A60 /* SnapshotsView.swift in Sources */,
 				511BA59223F4031F00E3E660 /* ControlView.swift in Sources */,
 				5534158223FE0539005C0A41 /* Contributors.swift in Sources */,
 				3C13FF9B2BEF4D5100060A5C /* PathToTerminalTextFieldView.swift in Sources */,
@@ -651,6 +673,7 @@
 				51AB56EB2A141C57002B5A67 /* ColorHistoryController.swift in Sources */,
 				ACDF076823F7E91A00597B3B /* ApplicationType.swift in Sources */,
 				3C13FF952BEF499400060A5C /* NotificationsFormView.swift in Sources */,
+				4842FE542D0DFF0100DC6F82 /* SnapshotAction.swift in Sources */,
 				51AB56E92A141055002B5A67 /* ColorsView.swift in Sources */,
 				51B0242325C3106E0042394E /* AppSummaryView.swift in Sources */,
 				3C13FF992BEF4C9200060A5C /* ColorPickerView.swift in Sources */,
@@ -697,6 +720,7 @@
 				B07F584923F99A1700256D5D /* SimCtl+SubCommands.swift in Sources */,
 				551F8CF523F4AF7B0006D1BD /* SearchField.swift in Sources */,
 				AC472CCF240D46D7007FF521 /* KeyedEncodingContainer-NotEmpty.swift in Sources */,
+				48540AB12D0B4DFB004F04E4 /* SnapshotCtl.swift in Sources */,
 				51AB56E72A140D53002B5A67 /* NSColor-Conversions.swift in Sources */,
 				3C13FF972BEF4AAE00060A5C /* PickersFormView.swift in Sources */,
 				5FA79DA92A5752A9006F5477 /* XcodeHelper.swift in Sources */,

--- a/ControlRoom/Controllers/SimCtl+Types.swift
+++ b/ControlRoom/Controllers/SimCtl+Types.swift
@@ -13,6 +13,7 @@ extension SimCtl {
         case iOS
         case tvOS
         case watchOS
+        case visionOS
     }
 
     enum DeviceFamily: CaseIterable {
@@ -21,6 +22,7 @@ extension SimCtl {
         // swiftlint:disable:next identifier_name
         case tv
         case watch
+        case visionPro
 
         var displayName: String {
             switch self {
@@ -28,6 +30,16 @@ extension SimCtl {
             case .iPad: return "iPad"
             case .watch: return "Apple Watch"
             case .tv: return "Apple TV"
+            case .visionPro: return "Apple Vision Pro"
+            }
+        }
+        
+        var snapshotUnavailableIcon: String {
+            switch self {
+            case .iPad, .iPhone: return "iphone.slash"
+            case .watch: return "applewatch.slash"
+            case .tv: return "tv.slash"
+            case .visionPro: return "visionpro.slash"
             }
         }
     }
@@ -56,6 +68,7 @@ extension SimCtl {
             if type.conformsTo(.tv) { return .tv }
             if type.conformsTo(.watch) { return .watch }
             if type.conformsTo(.pad) { return .iPad }
+            if type.conformsTo(.vision) { return .visionPro }
             return .iPhone
         }
     }
@@ -96,6 +109,8 @@ extension SimCtl {
                 return [.watch]
             } else if name.hasPrefix("tvOS") {
                 return [.tv]
+            } else if name.hasPrefix("visionOS") {
+                return [.visionPro]
             } else {
                 return []
             }

--- a/ControlRoom/Controllers/SimCtl.swift
+++ b/ControlRoom/Controllers/SimCtl.swift
@@ -45,9 +45,12 @@ enum SimCtl: CommandLineCommandExecuter {
         execute(.boot(simulator: simulator))
     }
 
-    static func shutdown(_ simulator: String) {
-        execute(.shutdown(.devices([simulator])))
+    static func shutdown(_ simulator: String, completion: ((Result<Data, CommandLineError>) -> Void)? = nil) {
+        execute(.shutdown(.devices([simulator]))) { result in
+            completion?(result)
+        }
     }
+    
     static func setContentSize(_ simulator: String, contentSize: UI.ContentSizes) {
         execute(.ui(deviceId: simulator, option: .contentSize(contentSize)))
     }
@@ -160,6 +163,10 @@ enum SimCtl: CommandLineCommandExecuter {
 
     static func delete(_ simulators: Set<String>) {
         execute(.delete(.devices(Array(simulators))))
+        
+        if let simulator = simulators.first {
+            SnapshotCtl.deleteAllSnapshots(deviceId: simulator)
+        }
     }
 
     static func uninstall(_ simulator: String, appID: String) {

--- a/ControlRoom/Controllers/Simulator.swift
+++ b/ControlRoom/Controllers/Simulator.swift
@@ -58,7 +58,7 @@ struct Simulator: Identifiable, Comparable {
             case .shuttingDown: false
             case .shutdown: true
             }
-        }
+        }        
     }
 
     /// The user-facing name for this simulator, e.g. iPhone 11 Pro Max.
@@ -84,7 +84,7 @@ struct Simulator: Identifiable, Comparable {
 
     /// The device type of the simulator
     let deviceType: DeviceType?
-
+    
     /// The current state of the simulator
     private(set) var state: State
 
@@ -114,6 +114,8 @@ struct Simulator: Identifiable, Comparable {
             typeIdentifier = .defaultWatch
         } else if name.contains("TV") {
             typeIdentifier = .defaultTV
+        } else if name.contains("Vision") {
+            typeIdentifier = .defaultVision
         } else {
             typeIdentifier = .defaultiPhone
         }
@@ -125,7 +127,7 @@ struct Simulator: Identifiable, Comparable {
     mutating func update(state: State) {
         self.state = state
     }
-
+    
     func open(_ filePath: FilePathKind) {
         NSWorkspace.shared.activateFileViewerSelecting([urlForFilePath(filePath)])
     }

--- a/ControlRoom/Controllers/Snapshot.swift
+++ b/ControlRoom/Controllers/Snapshot.swift
@@ -1,0 +1,24 @@
+//
+//  Snapshot.swift
+//  ControlRoom
+//
+//  Created by Marcel Mendes on 12/12/24.
+//  Copyright © 2024 Paul Hudson. All rights reserved.
+//
+import Foundation
+
+struct Snapshot: Equatable, Hashable, Identifiable {
+    let id: String
+    let creationDate: Date
+    let size: Int
+    
+    static func == (lhs: Snapshot, rhs: Snapshot) -> Bool {
+        lhs.id == rhs.id
+    }
+    
+    init(id: String, creationDate: Date, size: Int) {
+        self.id = id
+        self.creationDate = creationDate
+        self.size = size
+    }
+}

--- a/ControlRoom/Controllers/SnapshotCtl+Commands.swift
+++ b/ControlRoom/Controllers/SnapshotCtl+Commands.swift
@@ -1,0 +1,32 @@
+//
+//  Command.swift
+//  ControlRoom
+//
+//  Created by Marcel Mendes on 12/12/24.
+//  Copyright © 2024 Paul Hudson. All rights reserved.
+//
+
+import Foundation
+
+extension SnapshotCtl {
+    
+    struct Command: CommandLineCommand {
+        static let snapshotsFolder: String = ".snapshots"
+
+        var command: String?
+        let arguments: [String]
+        let environmentOverrides: [String: String]?
+        
+        private init(_ command: String, arguments: [String], environmentOverrides: [String: String]? = nil) {
+            self.command = command
+            self.arguments = arguments
+            self.environmentOverrides = environmentOverrides
+        }
+        
+        static func createSnapshotTree(deviceId: String, snapshotName: String) -> Command {
+            Command("/bin/mkdir", arguments:["-p", "\(devicesPath)/\(snapshotsFolder)/\(deviceId)/\(snapshotName)"])
+        }
+        
+    }
+    
+}

--- a/ControlRoom/Controllers/SnapshotCtl.swift
+++ b/ControlRoom/Controllers/SnapshotCtl.swift
@@ -1,0 +1,102 @@
+//
+//  SnapshotCtl.swift
+//  ControlRoom
+//
+//  Created by Marcel Mendes on 12/12/24.
+//  Copyright © 2024 Paul Hudson. All rights reserved.
+//
+
+import Foundation
+import Combine
+
+enum SnapshotCtl: CommandLineCommandExecuter {
+    typealias Error = CommandLineError
+    
+    static var launchPath = ""
+    static var snapshotsPath = ""
+    static var devicesPath = "" {
+        didSet {
+            snapshotsPath = devicesPath + "/.snapshots"
+        }
+    }
+    
+    static func configureDevicesPath(dataPath: String?) {
+        guard let dataPath else {
+            print("Missing dataPath. Snapshots won't be created.")
+            return
+        }
+        
+        var folders: [String] = []
+        
+        dataPath.split(separator: "/").forEach {
+            folders.append("\($0)")
+        }
+        
+        if let devicesIndex: Int = folders.firstIndex(of: "Devices") {
+            devicesPath = "/" + folders.prefix(devicesIndex + 1).joined(separator: "/")
+        }
+    }
+
+    static func getSnapshots(deviceId: String) -> [Snapshot] {
+        let snapshotsPath: String = devicesPath + "/.snapshots/" + deviceId
+        var snapshotIDs: [String] = []
+        var snapshots: [Snapshot] = []
+        
+        do {
+            snapshotIDs = try FileManager.default.contentsOfDirectory(atPath: snapshotsPath)
+        } catch { }
+        
+        snapshotIDs.forEach { snapshotID in
+            guard !snapshotID.hasPrefix(".") else { return }
+
+            let snapshotPath: String = snapshotsPath + "/" + snapshotID
+            let snapshotAttributes = getSnapshotAttributes(snapshotPath)
+
+            guard let creationDate = snapshotAttributes.creationDate,
+                  let snapshotFolderSize = snapshotAttributes.folderSize else { return }
+            let snapshot: Snapshot = .init(id: snapshotID, creationDate: creationDate, size: snapshotFolderSize)
+            snapshots.append(snapshot)
+        }
+        
+        return snapshots
+    }
+    
+    static func createSnapshot(deviceId: String, snapshotName: String) {
+        SimCtl.shutdown(deviceId) { _ in
+            execute(.createSnapshotTree(deviceId: deviceId, snapshotName: snapshotName)) { _ in
+                try? FileManager.default.copyItem(atPath: devicesPath + "/" + deviceId, toPath: snapshotsPath + "/" + deviceId + "/" + snapshotName + "/" + deviceId)
+            }
+        }
+    }
+    
+    static func renameSnapshot(deviceId: String, snapshotName: String, newSnapshotName: String) {
+        let snapshotPath: String = snapshotsPath + "/" + deviceId
+        try? FileManager.default.moveItem(atPath: snapshotPath + "/" + snapshotName, toPath: snapshotPath + "/" + newSnapshotName)
+    }
+    
+    static func deleteSnapshot(deviceId: String, snapshotName: String) {
+        let snapshotPath: String = snapshotsPath + "/" + deviceId
+        try? FileManager.default.removeItem(atPath: snapshotPath + "/" + snapshotName)
+    }
+    
+    static func deleteAllSnapshots(deviceId: String) {
+        let snapshotPath: String = snapshotsPath + "/" + deviceId
+        try? FileManager.default.removeItem(atPath: snapshotPath)
+    }
+    
+    static func restoreSnapshot(deviceId: String, snapshotName: String) {
+        let snapshotPath: String = snapshotsPath + "/" + deviceId
+
+        SimCtl.shutdown(deviceId) { _ in
+            try? FileManager.default.removeItem(atPath: devicesPath + "/" + deviceId)
+            try? FileManager.default.copyItem(atPath: snapshotPath + "/" + snapshotName + "/" + deviceId, toPath: devicesPath + "/" + deviceId)
+        }
+    }
+    
+    private static func getSnapshotAttributes(_ snapshotPath: String) -> URLFileAttribute {
+        let snapshotURL: URL = URL(fileURLWithPath: snapshotPath)
+        let snapshotAttributes = URLFileAttribute(url: snapshotURL)
+        return snapshotAttributes
+    }
+        
+}

--- a/ControlRoom/Helpers/CommandLineExecuter.swift
+++ b/ControlRoom/Helpers/CommandLineExecuter.swift
@@ -42,6 +42,7 @@ enum CommandLineError: Error {
 }
 
 protocol CommandLineCommand {
+    var command: String? { get }
     var arguments: [String] { get }
     var environmentOverrides: [String: String]? { get }
 }
@@ -51,11 +52,17 @@ protocol CommandLineCommandExecuter {
     static var launchPath: String { get }
 }
 
+extension CommandLineCommand {
+    var command: String? { nil }
+}
+
 extension CommandLineCommandExecuter {
 
     private static func execute(_ command: Command, completion: @escaping (Result<Data, CommandLineError>) -> Void) {
+        let commandToExecute: String = command.command ?? launchPath
+        
         DispatchQueue.global(qos: .userInitiated).async {
-            if let data = Process.execute(launchPath, arguments: command.arguments, environmentOverrides: command.environmentOverrides) {
+            if let data = Process.execute(commandToExecute, arguments: command.arguments, environmentOverrides: command.environmentOverrides) {
                 completion(.success(data))
             } else {
                 completion(.failure(.missingCommand))
@@ -90,6 +97,7 @@ extension CommandLineCommandExecuter {
 
         return publisher
     }
+    
     static func execute(_ command: Command, completion: ((Result<Data, CommandLineError>) -> Void)? = nil) {
         execute(command, completion: completion ?? { _ in })
     }

--- a/ControlRoom/Helpers/TypeIdentifier.swift
+++ b/ControlRoom/Helpers/TypeIdentifier.swift
@@ -15,6 +15,7 @@ struct TypeIdentifier: Hashable {
     static let phone = TypeIdentifier("com.apple.iphone")
     static let pad = TypeIdentifier("com.apple.ipad")
     static let watch = TypeIdentifier("com.apple.watch")
+    static let vision = TypeIdentifier("com.apple.vision-pro")
 
     // swiftlint:disable:next identifier_name
     static let tv = TypeIdentifier("com.apple.apple-tv")
@@ -24,6 +25,7 @@ struct TypeIdentifier: Hashable {
     static let defaultiPad = TypeIdentifier("com.apple.ipad-pro-12point9-2")
     static let defaultWatch = TypeIdentifier("com.apple.watch-series5-1")
     static let defaultTV = TypeIdentifier("com.apple.apple-tv-4k")
+    static let defaultVision = TypeIdentifier("com.apple.vision-pro")
 
     static func == (lhs: TypeIdentifier, rhs: TypeIdentifier) -> Bool {
         lhs.rawValue == rhs.rawValue

--- a/ControlRoom/Helpers/URLFileAttribute.swift
+++ b/ControlRoom/Helpers/URLFileAttribute.swift
@@ -1,0 +1,49 @@
+//
+//  URLFileAttribute.swift
+//  ControlRoom
+//
+//  Created by Marcel Mendes on 14/12/24.
+//  Copyright © 2024 Paul Hudson. All rights reserved.
+//
+
+import Foundation
+
+struct URLFileAttribute {
+    private(set) var folderSize: Int? = nil
+    private(set) var creationDate: Date? = nil
+    private(set) var modificationDate: Date? = nil
+
+    init(url: URL) {
+        let path = url.path
+        guard let dictionary: [FileAttributeKey: Any] = try? FileManager.default
+                .attributesOfItem(atPath: path) else {
+            return
+        }
+
+        if dictionary.keys.contains(FileAttributeKey.creationDate),
+            let value = dictionary[FileAttributeKey.creationDate] as? Date {
+            self.creationDate = value
+        }
+
+        if dictionary.keys.contains(FileAttributeKey.modificationDate),
+            let value = dictionary[FileAttributeKey.modificationDate] as? Date {
+            self.modificationDate = value
+        }
+        
+        folderSize = getFolderSize(url: url)
+    }
+    
+    private func getFolderSize(url: URL) -> Int {
+        guard let enumerator = FileManager.default.enumerator(at: url, includingPropertiesForKeys: [.fileSizeKey]) else { return 0 }
+        var size: Int = 0
+        for case let fileURL as URL in enumerator {
+            guard let fileSize = try? fileURL.resourceValues(forKeys: [.fileSizeKey]).fileSize else {
+                continue
+            }
+            size += fileSize
+        }
+        return size
+    }
+
+}
+

--- a/ControlRoom/Main Window/SimulatorAction.swift
+++ b/ControlRoom/Main Window/SimulatorAction.swift
@@ -12,6 +12,7 @@ enum Action: Int, Identifiable {
     case power
     case rename
     case clone
+    case createSnapshot
     case delete
     case openRoot
 
@@ -22,6 +23,7 @@ enum Action: Int, Identifiable {
         case .power: ""
         case .rename: "Rename Simulator"
         case .clone: "Clone Simulator"
+        case .createSnapshot: "Create Snapshot"
         case .delete: "Delete Simulator"
         case .openRoot: ""
         }
@@ -32,6 +34,7 @@ enum Action: Int, Identifiable {
         case .power: ""
         case .rename: "Enter a new name for this simulator. It may be the same as the name of an existing simulator, but a unique name will make it easier to identify."
         case .clone: "Enter a name for the new simulator. It may be the same as the name of an existing simulator, but a unique name will make it easier to identify."
+        case .createSnapshot: ""
         case .delete: "Are you sure you want to delete this simulator? You will not be able to undo this action."
         case .openRoot: ""
         }
@@ -42,6 +45,7 @@ enum Action: Int, Identifiable {
         case .power: "Power"
         case .rename: "Rename"
         case .clone: "Clone"
+        case .createSnapshot: "Create"
         case .delete: "Delete"
         case .openRoot: ""
         }

--- a/ControlRoom/Main Window/SimulatorSidebarView.swift
+++ b/ControlRoom/Main Window/SimulatorSidebarView.swift
@@ -66,6 +66,7 @@ struct SimulatorSidebarView: View {
                 Button("Rename...") { action = .rename }
                 Button("Clone...") { action = .clone }
                     .disabled(simulator.state == .booted)
+                Button("Create snapshot...") { performAction(.createSnapshot) }
                 Button("Delete...") { action = .delete }
                 Divider()
                 Button("Open in Finder") { performAction(.openRoot) }
@@ -73,7 +74,7 @@ struct SimulatorSidebarView: View {
         )
         .sheet(item: $action) { action in
             switch action {
-            case .power, .openRoot:
+            case .power, .openRoot, .createSnapshot:
                 EmptyView()
             case .rename, .clone:
                 SimulatorActionSheet(
@@ -104,6 +105,7 @@ struct SimulatorSidebarView: View {
         switch action {
         case .rename: SimCtl.rename(simulator.udid, name: newName)
         case .clone: SimCtl.clone(simulator.udid, name: newName)
+        case .createSnapshot: SnapshotCtl.createSnapshot(deviceId: simulator.udid, snapshotName: UUID().uuidString)
         case .delete: SimCtl.delete([simulator.udid])
         case .power:
             if simulator.state == .booted {

--- a/ControlRoom/Simulator UI/ControlScreens/SnapshotAction.swift
+++ b/ControlRoom/Simulator UI/ControlScreens/SnapshotAction.swift
@@ -1,0 +1,41 @@
+//
+//  SnapshotAction.swift
+//  ControlRoom
+//
+//  Created by Marcel Mendes on 14/12/24.
+//  Copyright © 2024 Paul Hudson. All rights reserved.
+//
+
+import struct SwiftUI.LocalizedStringKey
+
+enum SnapshotAction: Int, Identifiable {
+    case delete
+    case rename
+    case restore
+
+    var id: Int { rawValue }
+
+    var sheetTitle: LocalizedStringKey {
+        switch self {
+        case .delete: "Delete Snapshot"
+        case .rename: "Rename Snapshot"
+        case .restore: "Restore Snapshot"
+        }
+    }
+
+    var sheetMessage: LocalizedStringKey {
+        switch self {
+        case .delete: "Are you sure you want to delete this snapshot? You will not be able to undo this action."
+        case .rename: "Enter a new name for this snapshot. It must be unique."
+        case .restore: "Are you sure you want to restore this snapshot? You will not be able to undo this action."
+        }
+    }
+
+    var saveActionTitle: LocalizedStringKey {
+        switch self {
+        case .delete: "Delete"
+        case .rename: "Rename"
+        case .restore: "Restore"
+        }
+    }
+}

--- a/ControlRoom/Simulator UI/ControlScreens/SnapshotsView.swift
+++ b/ControlRoom/Simulator UI/ControlScreens/SnapshotsView.swift
@@ -1,0 +1,141 @@
+//
+//  SnapshotsView.swift
+//  ControlRoom
+//
+//  Created by Marcel Mendes on 14/12/24.
+//  Copyright © 2024 Paul Hudson. All rights reserved.
+//
+
+
+import SwiftUI
+
+struct SnapshotsView: View {
+	let simulator: Simulator
+	@ObservedObject var controller: SimulatorsController
+    
+    @State private var snapshotAction: SnapshotAction?
+    @State private var newName: String
+    @State private var selectedSnapshotName: String
+    
+    init(simulator: Simulator, controller: SimulatorsController) {
+        self.simulator = simulator
+        self.controller = controller
+        self._newName = State(initialValue: simulator.name)
+        self._selectedSnapshotName = State(initialValue: simulator.name)
+    }
+
+    private let formatter = MeasurementFormatter()
+
+	var body: some View {
+		ScrollView {
+            if controller.snapshots.count > 0 {
+                Form {
+					Section {
+						LabeledContent("Snapshots:") {
+							VStack(alignment: .leading, spacing: 5) {
+                                ForEach(controller.snapshots.sorted(by: { $0.creationDate > $1.creationDate }), id: \.id) { snapshot in
+                                    
+                                    let folderSize = Measurement(value: Double(snapshot.size), unit: UnitInformationStorage.bytes)
+                                                                        
+									HStack {
+                                        Button {
+                                            restore(snapshot: snapshot.id)
+                                        } label: {
+                                            Label("Restore", systemImage: "arrow.counterclockwise")
+                                        }
+
+                                        Button {
+                                            rename(snapshot: snapshot.id)
+                                        } label: {
+                                            Label("Rename", systemImage: "pencil")
+                                        }
+
+                                        Text(snapshot.id)
+                                            .fontWeight(.semibold)
+                                        
+                                        Group {
+                                            Text(snapshot.creationDate.formatted(date: .numeric, time: .standard))
+                                            Text(formatter.string(from: folderSize.converted(to: .gigabytes)))
+                                        }
+                                        .font(.callout)
+                                        .fontWeight(.thin)
+
+                                        Button {
+                                            delete(snapshot: snapshot.id)
+                                        } label: {
+                                            Label("Delete", systemImage: "trash")
+                                        }
+                                        
+                                        Spacer()
+									}
+								}
+							}
+						}
+					}
+                }
+                .padding()
+            } else {
+                VStack(spacing: 10) {
+                    Spacer()
+                    Image(systemName: simulator.deviceFamily.snapshotUnavailableIcon)
+                    Text("No snapshots yet")
+                }
+                .font(.title)
+			}
+		}
+        .tabItem {
+            Text("Snapshots")
+        }
+        .sheet(item: $snapshotAction) { action in
+            switch action {
+            case .rename:
+                SimulatorActionSheet(
+                    icon: simulator.image,
+                    message: action.sheetTitle,
+                    informativeText: action.sheetMessage,
+                    confirmationTitle: action.saveActionTitle,
+                    confirm: { performAction(action) },
+                    canConfirm: newName.isNotEmpty,
+                    content: {
+                        TextField("Name", text: $newName)
+                    }
+                )
+            case .delete, .restore:
+                SimulatorActionSheet(
+                    icon: simulator.image,
+                    message: action.sheetTitle,
+                    informativeText: action.sheetMessage,
+                    confirmationTitle: action.saveActionTitle,
+                    confirm: { performAction(action) })
+            }
+        }
+
+	}
+
+    private func rename(snapshot: String) {
+        selectedSnapshotName = snapshot
+        newName = snapshot
+        snapshotAction = .rename
+    }
+    
+    private func delete(snapshot: String) {
+        selectedSnapshotName = snapshot
+        snapshotAction = .delete
+    }
+
+    private func restore(snapshot: String) {
+        selectedSnapshotName = snapshot
+        snapshotAction = .restore
+    }
+
+    private func performAction(_ action: SnapshotAction) {
+        switch action {
+        case .delete: SnapshotCtl.deleteSnapshot(deviceId: simulator.udid, snapshotName: selectedSnapshotName)
+        case .rename: SnapshotCtl.renameSnapshot(deviceId: simulator.udid, snapshotName: selectedSnapshotName, newSnapshotName: newName)
+        case .restore: SnapshotCtl.restoreSnapshot(deviceId: simulator.udid, snapshotName: selectedSnapshotName)
+        }
+    }
+        
+	func placeholder() {}
+
+}

--- a/ControlRoom/Simulator UI/ControlScreens/SystemView/SystemView.swift
+++ b/ControlRoom/Simulator UI/ControlScreens/SystemView/SystemView.swift
@@ -230,8 +230,10 @@ struct SystemView: View {
 
 struct SystemView_Previews: PreviewProvider {
     static var previews: some View {
-        SystemView(simulator: .example)
-            .environmentObject(Preferences())
+		let preferences = Preferences()
+
+		SystemView(simulator: .example, controller: SimulatorsController(preferences: preferences))
+			.environmentObject(preferences)
     }
 }
 

--- a/ControlRoom/Simulator UI/ControlView.swift
+++ b/ControlRoom/Simulator UI/ControlView.swift
@@ -21,14 +21,19 @@ struct ControlView: View {
 
     var body: some View {
         TabView {
-            SystemView(simulator: simulator)
-            AppView(simulator: simulator, applications: applications)
-            LocationView(controller: controller, simulator: simulator)
-            StatusBarView(simulator: simulator)
-            OverridesView(simulator: simulator)
-            ColorsView()
+            SystemView(simulator: simulator, controller: controller)
+                .disabled(simulator.state != .booted)
+            SnapshotsView(simulator: simulator, controller: controller)
+            Group {
+                AppView(simulator: simulator, applications: applications)
+                LocationView(controller: controller, simulator: simulator)
+                StatusBarView(simulator: simulator)
+                OverridesView(simulator: simulator)
+                ColorsView()
+            }
+            .disabled(simulator.state != .booted)
+
         }
-        .disabled(simulator.state != .booted)
         .navigationSubtitle("\(simulator.name) – \(simulator.runtime?.name ?? "Unknown OS")")
         .toolbar {
             Menu("Save \(captureController.imageFormatString)") {


### PR DESCRIPTION
Hello!

I’ve created a new and interesting feature: simulator snapshots.

Simulator snapshots work in the same way as virtual machine snapshots: they are a snapshot of the simulator that you can restore at any time.

This feature saves me a lot of time because:
a) I spend time configuring the simulator and my app to test new features – and I’d like to preserve that configuration so I can repeat feature journeys that modify the app's behaviour;
b) I spend time configuring the simulator and my app to reproduce a specific bug – and I’d like to preserve that configuration so I can repeat the bug reproduction and test different potential fixes and their quality.

To create a simulator snapshot: double-click the simulator and select "Create snapshot".

To manage snapshots: select the simulator and go to the Snapshots tab.

This improvement has been incredibly useful for my day-to-day work, and I’d like to share it with the community.

Thank you!

Marcel