### PR TITLE
fix: #157 Simulator isn't visible on booting it from Control Room

### DIFF
--- a/ControlRoom/Controllers/SimCtl.swift
+++ b/ControlRoom/Controllers/SimCtl.swift
@@ -42,7 +42,13 @@ enum SimCtl: CommandLineCommandExecuter {
     }
 
     static func boot(_ simulator: Simulator) {
-        execute(.boot(simulator: simulator))
+        /// No need to check if Simulator app is already running since no second SImulator app will be spawned
+        SnapshotCtl.startSimulatorApp {
+            /// Wait for a little while Simulator app starts running, then proceed to boot simulator
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                execute(.boot(simulator: simulator))
+            }
+        }
     }
 
     static func shutdown(_ simulator: String, completion: ((Result<Data, CommandLineError>) -> Void)? = nil) {

--- a/ControlRoom/Controllers/SnapshotCtl+Commands.swift
+++ b/ControlRoom/Controllers/SnapshotCtl+Commands.swift
@@ -27,6 +27,10 @@ extension SnapshotCtl {
             Command("/bin/mkdir", arguments:["-p", "\(devicesPath)/\(snapshotsFolder)/\(deviceId)/\(snapshotName)"])
         }
         
+        /// Open app
+        static func open(app: String) -> Command {
+            Command("/usr/bin/open", arguments: ["-a", app])
+        }
     }
     
 }

--- a/ControlRoom/Controllers/SnapshotCtl.swift
+++ b/ControlRoom/Controllers/SnapshotCtl.swift
@@ -93,10 +93,16 @@ enum SnapshotCtl: CommandLineCommandExecuter {
         }
     }
     
+    static func startSimulatorApp(completion: @escaping (() -> Void)) {
+        execute(.open(app: "Simulator.app")) { _ in
+            return completion()
+        }
+    }
+
     private static func getSnapshotAttributes(_ snapshotPath: String) -> URLFileAttribute {
         let snapshotURL: URL = URL(fileURLWithPath: snapshotPath)
         let snapshotAttributes = URLFileAttribute(url: snapshotURL)
         return snapshotAttributes
     }
-        
+    
 }


### PR DESCRIPTION
This PR fixes issue #157 - simulator isn't visible after booting it from Control Room when Simulator app is not running already.
