### PR TITLE
Add feature to clear the Status Bar overrides

### DIFF
--- a/ControlRoom/Controllers/SimCtl.swift
+++ b/ControlRoom/Controllers/SimCtl.swift
@@ -113,6 +113,10 @@ enum SimCtl: CommandLineCommandExecuter {
         ])))
     }
 
+    static func clearStatusBarOverrides(_ simulator: String) {
+        execute(.statusBar(deviceId: simulator, operation: .clear))
+    }
+
     static func overrideStatusBarTime(_ simulator: String, time: Date) {
         // Use only time for now since ISO8601 parsing is broken since Xcode 15.3
         // https://stackoverflow.com/a/59071895

--- a/ControlRoom/Simulator UI/ControlScreens/StatusBarView.swift
+++ b/ControlRoom/Simulator UI/ControlScreens/StatusBarView.swift
@@ -47,6 +47,8 @@ struct StatusBarView: View {
                         DatePicker("Time:", selection: $time)
                         Button("Set", action: setTime)
                         Button("Set to 9:41", action: setAppleTime)
+                        Spacer()
+                        Button("Clear overrides", action: clearOverrides)
                     }
                 }
 
@@ -151,6 +153,10 @@ struct StatusBarView: View {
         SimCtl.overrideStatusBarTime(simulator.udid, time: appleTime)
 
         time = appleTime
+    }
+
+    private func clearOverrides() {
+        SimCtl.clearStatusBarOverrides(simulator.udid)
     }
 
     /// Sends status bar updates all at once; simctl gets unhappy if we send them individually, but

--- a/ControlRoom/Simulator UI/ControlScreens/StatusBarView.swift
+++ b/ControlRoom/Simulator UI/ControlScreens/StatusBarView.swift
@@ -157,6 +157,13 @@ struct StatusBarView: View {
 
     private func clearOverrides() {
         SimCtl.clearStatusBarOverrides(simulator.udid)
+        dataNetwork = .wifi
+        wiFiBar = .three
+        cellularMode = .active
+        cellularBar = .four
+        batteryLevel = 100.0
+        batteryState = .charged
+        carrierName = "Carrier"
     }
 
     /// Sends status bar updates all at once; simctl gets unhappy if we send them individually, but

--- a/ControlRoom/Simulator UI/ControlScreens/StatusBarView.swift
+++ b/ControlRoom/Simulator UI/ControlScreens/StatusBarView.swift
@@ -37,7 +37,7 @@ struct StatusBarView: View {
 
     /// The current battery state of the device; must be "Charging", "Charged", or "Discharging"
     /// Note: "Charged" looks the same as "Discharging", so it's not included in this screen.
-    @State private var batteryState: SimCtl.StatusBar.BatteryState = .charging
+    @State private var batteryState: SimCtl.StatusBar.BatteryState = .charged
 
     var body: some View {
         ScrollView {


### PR DESCRIPTION
Although being able to override the status bar is great, sometimes you may want it to reset to its original state. 

This PR adds a little UI and wiring to the underlying `Simctl` command.
It also resets the local UI state so as to not confuse the user about what they should be seeing on their simulator vs the Control Room UI.

Happy to move the button or rename things as you see fit 👍

![ControlRoom - Status bar reset](https://github.com/user-attachments/assets/d626ce6a-4603-4cee-9370-2c7f6087d5d2)
