### PR TITLE
Add .editorconfig to help with formatting, clear whitespace warnings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# Set default charset
+[*.{swift,plist,yml,md}]
+indent_style = space
+charset = utf-8
+
+# 4 space indentation
+[*.{swift,yml}]
+indent_size = 4
+
+[*.md]
+indent_size = 2
+
+[{Makefile,makefile}]
+indent_style = tab

--- a/ControlRoom.xcodeproj/project.pbxproj
+++ b/ControlRoom.xcodeproj/project.pbxproj
@@ -181,6 +181,7 @@
 		55DF68BC23F8C76800E717D3 /* Collection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Collection.swift; sourceTree = "<group>"; };
 		5FA79DA82A5752A9006F5477 /* XcodeHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcodeHelper.swift; sourceTree = "<group>"; };
 		70BE435923F54B7200FD6282 /* LocationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationView.swift; sourceTree = "<group>"; };
+		7C40DEF22DB93D9F004C24BB /* .editorconfig */ = {isa = PBXFileReference; lastKnownFileType = text; path = .editorconfig; sourceTree = "<group>"; };
 		AC472CCE240D46D7007FF521 /* KeyedEncodingContainer-NotEmpty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KeyedEncodingContainer-NotEmpty.swift"; sourceTree = "<group>"; };
 		AC472CFA240D5F22007FF521 /* NotificationEditorView.strings */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; path = NotificationEditorView.strings; sourceTree = "<group>"; };
 		ACCD798B240ADEE20004ECE5 /* NotificationEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationEditorView.swift; sourceTree = "<group>"; };
@@ -228,6 +229,7 @@
 				B07F584F23F9F83800256D5D /* ControlRoomTests */,
 				511BA57A23F3FFEA00E3E660 /* Products */,
 				555A145823F70A5100313BC5 /* Frameworks */,
+				7C40DEF22DB93D9F004C24BB /* .editorconfig */,
 			);
 			sourceTree = "<group>";
 		};

--- a/ControlRoom/Controllers/DeepLinksController.swift
+++ b/ControlRoom/Controllers/DeepLinksController.swift
@@ -46,7 +46,7 @@ class DeepLinksController: ObservableObject {
             save()
         }
     }
-    
+
     /// Updates an existing DeepLink with the new name and URL. No changes are made if the `itemID` is `nil`, a matching
     /// DeepLink cannot be found or if the new stringified URL fails construction as a `URL`.
     /// - Parameters:
@@ -61,12 +61,12 @@ class DeepLinksController: ObservableObject {
         else {
             return
         }
-        
+
         var link = links[index]
         link.name = name
         link.url = verifiedURL
         links[index] = link
-        
+
         save()
     }
 
@@ -89,14 +89,14 @@ class DeepLinksController: ObservableObject {
         links.sort(using: comparator)
         save()
     }
-    
+
     /// Finds the first deep link matching the desired DeepLink.ID
     /// - Parameter itemID: The identifier to search for.
     /// - Returns: The first matching DeepLink if one is found. Returns `nil` if no matching link is found or if
     /// `itemID` parameter is `nil`.
     func link(_ itemID: DeepLink.ID?) -> DeepLink? {
         guard let itemID else { return nil }
-        
+
         return links.first(where: { $0.id == itemID })
     }
 }

--- a/ControlRoom/Controllers/SimCtl+SubCommands.swift
+++ b/ControlRoom/Controllers/SimCtl+SubCommands.swift
@@ -558,7 +558,7 @@ extension SimCtl {
 
         var rawValue: String {
           switch self {
-            case .desktop:
+          case .desktop:
               return "Desktop"
           case .other(let url):
               return url.absoluteString

--- a/ControlRoom/Controllers/SimCtl+Types.swift
+++ b/ControlRoom/Controllers/SimCtl+Types.swift
@@ -33,7 +33,7 @@ extension SimCtl {
             case .visionPro: return "Apple Vision Pro"
             }
         }
-        
+
         var snapshotUnavailableIcon: String {
             switch self {
             case .iPad, .iPhone: return "iphone.slash"

--- a/ControlRoom/Controllers/SimCtl.swift
+++ b/ControlRoom/Controllers/SimCtl.swift
@@ -56,7 +56,7 @@ enum SimCtl: CommandLineCommandExecuter {
             completion?(result)
         }
     }
-    
+
     static func setContentSize(_ simulator: String, contentSize: UI.ContentSizes) {
         execute(.ui(deviceId: simulator, option: .contentSize(contentSize)))
     }
@@ -173,7 +173,7 @@ enum SimCtl: CommandLineCommandExecuter {
 
     static func delete(_ simulators: Set<String>) {
         execute(.delete(.devices(Array(simulators))))
-        
+
         if let simulator = simulators.first {
             SnapshotCtl.deleteAllSnapshots(deviceId: simulator)
         }

--- a/ControlRoom/Controllers/Simulator.swift
+++ b/ControlRoom/Controllers/Simulator.swift
@@ -58,7 +58,7 @@ struct Simulator: Identifiable, Comparable {
             case .shuttingDown: false
             case .shutdown: true
             }
-        }        
+        }
     }
 
     /// The user-facing name for this simulator, e.g. iPhone 11 Pro Max.
@@ -84,7 +84,7 @@ struct Simulator: Identifiable, Comparable {
 
     /// The device type of the simulator
     let deviceType: DeviceType?
-    
+
     /// The current state of the simulator
     private(set) var state: State
 
@@ -127,7 +127,7 @@ struct Simulator: Identifiable, Comparable {
     mutating func update(state: State) {
         self.state = state
     }
-    
+
     func open(_ filePath: FilePathKind) {
         NSWorkspace.shared.activateFileViewerSelecting([urlForFilePath(filePath)])
     }

--- a/ControlRoom/Controllers/SimulatorsController.swift
+++ b/ControlRoom/Controllers/SimulatorsController.swift
@@ -35,7 +35,7 @@ class SimulatorsController: ObservableObject {
 
     /// An array of all the applications installed on the selected simulator.
     @Published var applications = [Application]()
-    
+
     /// An array of all the snapshots of the selected simulator.
     @Published var snapshots = [Snapshot]()
 
@@ -138,7 +138,7 @@ class SimulatorsController: ObservableObject {
                                     dataPath: device.dataPath ?? "")
                 final.append(sim)
             }
-            
+
             if let device = devices.first {
                 SnapshotCtl.configureDevicesPath(dataPath: device.dataPath)
             }
@@ -211,18 +211,18 @@ class SimulatorsController: ObservableObject {
             .assign(to: \.applications, on: self)
             .store(in: &cancellables)
     }
-    
+
     private func loadSnapshots() {
         guard
             let selectedDeviceUDID = selectedSimulatorIDs.first
             else { return }
-        
+
         DispatchQueue.main.async {
             self.snapshots = SnapshotCtl.getSnapshots(deviceId: selectedDeviceUDID)
         }
 
         timer?.invalidate()
-        
+
         timer = .init(timeInterval: 5, repeats: true) { _ in
             DispatchQueue.main.async {
                 self.snapshots = SnapshotCtl.getSnapshots(deviceId: selectedDeviceUDID)
@@ -231,12 +231,12 @@ class SimulatorsController: ObservableObject {
 
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             guard let timer = self?.timer else { return }
-            
+
             let runLoop = RunLoop.current
             runLoop.add(timer, forMode: .default)
             runLoop.run()
         }
 
     }
-    
+
 }

--- a/ControlRoom/Controllers/Snapshot.swift
+++ b/ControlRoom/Controllers/Snapshot.swift
@@ -11,11 +11,11 @@ struct Snapshot: Equatable, Hashable, Identifiable {
     let id: String
     let creationDate: Date
     let size: Int
-    
+
     static func == (lhs: Snapshot, rhs: Snapshot) -> Bool {
         lhs.id == rhs.id
     }
-    
+
     init(id: String, creationDate: Date, size: Int) {
         self.id = id
         self.creationDate = creationDate

--- a/ControlRoom/Controllers/SnapshotCtl+Commands.swift
+++ b/ControlRoom/Controllers/SnapshotCtl+Commands.swift
@@ -9,28 +9,28 @@
 import Foundation
 
 extension SnapshotCtl {
-    
+
     struct Command: CommandLineCommand {
         static let snapshotsFolder: String = ".snapshots"
 
         var command: String?
         let arguments: [String]
         let environmentOverrides: [String: String]?
-        
+
         private init(_ command: String, arguments: [String], environmentOverrides: [String: String]? = nil) {
             self.command = command
             self.arguments = arguments
             self.environmentOverrides = environmentOverrides
         }
-        
+
         static func createSnapshotTree(deviceId: String, snapshotName: String) -> Command {
-            Command("/bin/mkdir", arguments:["-p", "\(devicesPath)/\(snapshotsFolder)/\(deviceId)/\(snapshotName)"])
+            Command("/bin/mkdir", arguments: ["-p", "\(devicesPath)/\(snapshotsFolder)/\(deviceId)/\(snapshotName)"])
         }
-        
+
         /// Open app
         static func open(app: String) -> Command {
             Command("/usr/bin/open", arguments: ["-a", app])
         }
     }
-    
+
 }

--- a/ControlRoom/Controllers/SnapshotCtl.swift
+++ b/ControlRoom/Controllers/SnapshotCtl.swift
@@ -11,7 +11,7 @@ import Combine
 
 enum SnapshotCtl: CommandLineCommandExecuter {
     typealias Error = CommandLineError
-    
+
     static var launchPath = ""
     static var snapshotsPath = ""
     static var devicesPath = "" {
@@ -19,19 +19,19 @@ enum SnapshotCtl: CommandLineCommandExecuter {
             snapshotsPath = devicesPath + "/.snapshots"
         }
     }
-    
+
     static func configureDevicesPath(dataPath: String?) {
         guard let dataPath else {
             print("Missing dataPath. Snapshots won't be created.")
             return
         }
-        
+
         var folders: [String] = []
-        
+
         dataPath.split(separator: "/").forEach {
             folders.append("\($0)")
         }
-        
+
         if let devicesIndex: Int = folders.firstIndex(of: "Devices") {
             devicesPath = "/" + folders.prefix(devicesIndex + 1).joined(separator: "/")
         }
@@ -41,11 +41,11 @@ enum SnapshotCtl: CommandLineCommandExecuter {
         let snapshotsPath: String = devicesPath + "/.snapshots/" + deviceId
         var snapshotIDs: [String] = []
         var snapshots: [Snapshot] = []
-        
+
         do {
             snapshotIDs = try FileManager.default.contentsOfDirectory(atPath: snapshotsPath)
         } catch { }
-        
+
         snapshotIDs.forEach { snapshotID in
             guard !snapshotID.hasPrefix(".") else { return }
 
@@ -57,10 +57,10 @@ enum SnapshotCtl: CommandLineCommandExecuter {
             let snapshot: Snapshot = .init(id: snapshotID, creationDate: creationDate, size: snapshotFolderSize)
             snapshots.append(snapshot)
         }
-        
+
         return snapshots
     }
-    
+
     static func createSnapshot(deviceId: String, snapshotName: String) {
         SimCtl.shutdown(deviceId) { _ in
             execute(.createSnapshotTree(deviceId: deviceId, snapshotName: snapshotName)) { _ in
@@ -68,22 +68,22 @@ enum SnapshotCtl: CommandLineCommandExecuter {
             }
         }
     }
-    
+
     static func renameSnapshot(deviceId: String, snapshotName: String, newSnapshotName: String) {
         let snapshotPath: String = snapshotsPath + "/" + deviceId
         try? FileManager.default.moveItem(atPath: snapshotPath + "/" + snapshotName, toPath: snapshotPath + "/" + newSnapshotName)
     }
-    
+
     static func deleteSnapshot(deviceId: String, snapshotName: String) {
         let snapshotPath: String = snapshotsPath + "/" + deviceId
         try? FileManager.default.removeItem(atPath: snapshotPath + "/" + snapshotName)
     }
-    
+
     static func deleteAllSnapshots(deviceId: String) {
         let snapshotPath: String = snapshotsPath + "/" + deviceId
         try? FileManager.default.removeItem(atPath: snapshotPath)
     }
-    
+
     static func restoreSnapshot(deviceId: String, snapshotName: String) {
         let snapshotPath: String = snapshotsPath + "/" + deviceId
 
@@ -92,7 +92,7 @@ enum SnapshotCtl: CommandLineCommandExecuter {
             try? FileManager.default.copyItem(atPath: snapshotPath + "/" + snapshotName + "/" + deviceId, toPath: devicesPath + "/" + deviceId)
         }
     }
-    
+
     static func startSimulatorApp(completion: @escaping (() -> Void)) {
         execute(.open(app: "Simulator.app")) { _ in
             return completion()
@@ -104,5 +104,5 @@ enum SnapshotCtl: CommandLineCommandExecuter {
         let snapshotAttributes = URLFileAttribute(url: snapshotURL)
         return snapshotAttributes
     }
-    
+
 }

--- a/ControlRoom/Helpers/CommandLineExecuter.swift
+++ b/ControlRoom/Helpers/CommandLineExecuter.swift
@@ -60,7 +60,7 @@ extension CommandLineCommandExecuter {
 
     private static func execute(_ command: Command, completion: @escaping (Result<Data, CommandLineError>) -> Void) {
         let commandToExecute: String = command.command ?? launchPath
-        
+
         DispatchQueue.global(qos: .userInitiated).async {
             if let data = Process.execute(commandToExecute, arguments: command.arguments, environmentOverrides: command.environmentOverrides) {
                 completion(.success(data))
@@ -97,7 +97,7 @@ extension CommandLineCommandExecuter {
 
         return publisher
     }
-    
+
     static func execute(_ command: Command, completion: ((Result<Data, CommandLineError>) -> Void)? = nil) {
         execute(command, completion: completion ?? { _ in })
     }

--- a/ControlRoom/Helpers/URLFileAttribute.swift
+++ b/ControlRoom/Helpers/URLFileAttribute.swift
@@ -29,10 +29,10 @@ struct URLFileAttribute {
             let value = dictionary[FileAttributeKey.modificationDate] as? Date {
             self.modificationDate = value
         }
-        
+
         folderSize = getFolderSize(url: url)
     }
-    
+
     private func getFolderSize(url: URL) -> Int {
         guard let enumerator = FileManager.default.enumerator(at: url, includingPropertiesForKeys: [.fileSizeKey]) else { return 0 }
         var size: Int = 0
@@ -46,4 +46,3 @@ struct URLFileAttribute {
     }
 
 }
-

--- a/ControlRoom/Settings UI/PickersFormView.swift
+++ b/ControlRoom/Settings UI/PickersFormView.swift
@@ -69,7 +69,7 @@ struct PickersFormView: View {
           }
         }
     }
-    
+
     private func updateChromeSettings() {
         if renderChrome {
             captureSettings.mask = .alpha

--- a/ControlRoom/Simulator UI/ControlScreens/SnapshotsView.swift
+++ b/ControlRoom/Simulator UI/ControlScreens/SnapshotsView.swift
@@ -6,17 +6,16 @@
 //  Copyright © 2024 Paul Hudson. All rights reserved.
 //
 
-
 import SwiftUI
 
 struct SnapshotsView: View {
 	let simulator: Simulator
 	@ObservedObject var controller: SimulatorsController
-    
+
     @State private var snapshotAction: SnapshotAction?
     @State private var newName: String
     @State private var selectedSnapshotName: String
-    
+
     init(simulator: Simulator, controller: SimulatorsController) {
         self.simulator = simulator
         self.controller = controller
@@ -34,9 +33,9 @@ struct SnapshotsView: View {
 						LabeledContent("Snapshots:") {
 							VStack(alignment: .leading, spacing: 5) {
                                 ForEach(controller.snapshots.sorted(by: { $0.creationDate > $1.creationDate }), id: \.id) { snapshot in
-                                    
+
                                     let folderSize = Measurement(value: Double(snapshot.size), unit: UnitInformationStorage.bytes)
-                                                                        
+
 									HStack {
                                         Button {
                                             restore(snapshot: snapshot.id)
@@ -52,7 +51,7 @@ struct SnapshotsView: View {
 
                                         Text(snapshot.id)
                                             .fontWeight(.semibold)
-                                        
+
                                         Group {
                                             Text(snapshot.creationDate.formatted(date: .numeric, time: .standard))
                                             Text(formatter.string(from: folderSize.converted(to: .gigabytes)))
@@ -65,7 +64,7 @@ struct SnapshotsView: View {
                                         } label: {
                                             Label("Delete", systemImage: "trash")
                                         }
-                                        
+
                                         Spacer()
 									}
 								}
@@ -117,7 +116,7 @@ struct SnapshotsView: View {
         newName = snapshot
         snapshotAction = .rename
     }
-    
+
     private func delete(snapshot: String) {
         selectedSnapshotName = snapshot
         snapshotAction = .delete
@@ -135,7 +134,7 @@ struct SnapshotsView: View {
         case .restore: SnapshotCtl.restoreSnapshot(deviceId: simulator.udid, snapshotName: selectedSnapshotName)
         }
     }
-        
+
 	func placeholder() {}
 
 }

--- a/ControlRoom/Simulator UI/ControlScreens/SystemView/DeepLinkEditorView.swift
+++ b/ControlRoom/Simulator UI/ControlScreens/SystemView/DeepLinkEditorView.swift
@@ -26,7 +26,7 @@ struct DeepLinkEditorView: View {
 
     /// Whether we are currently showing the alert to let the user add a new deep link.
     @State private var showingAddAlert = false
-    
+
     /// Whether we are currently showing the sheet to let the user edit an existing deep link.
     @State private var showingEditSheet = false
 
@@ -47,7 +47,7 @@ struct DeepLinkEditorView: View {
                     TableColumn("URL", value: \.url.absoluteString)
                 }
                 .contextMenu(forSelectionType: DeepLink.ID.self) { _ in
-                    
+
                 } primaryAction: { _ in
                     showingEditSheet.toggle()
                 }
@@ -57,22 +57,22 @@ struct DeepLinkEditorView: View {
                 Button("Add New") {
                     showingAddAlert.toggle()
                 }
-                
+
                 Button("Edit") {
                     showingEditSheet.toggle()
                 }
                 .disabled(selection == nil)
-                
+
                 Button("Duplicate") {
                     duplicateSelected()
                 }
                 .disabled(selection == nil)
-                
+
                 Button("Delete") {
                     deleteSelected()
                 }
                 .disabled(selection == nil)
-                
+
                 Spacer()
                 Button("Done") { dismiss() }
             }
@@ -108,7 +108,7 @@ struct DeepLinkEditorView: View {
         deepLinks.delete(selection)
         selection = nil
     }
-    
+
     func duplicateSelected() {
         if let link = deepLinks.link(selection) {
             deepLinks.create(name: link.name + " (copy)", url: link.url.absoluteString)
@@ -124,24 +124,24 @@ private extension DeepLinkEditorView {
         @Binding var deepLink: DeepLink.ID?
         @State private var name: String = ""
         @State private var url: String = ""
-        
+
         var body: some View {
             VStack {
                 Text("Edit Deep Link")
                     .font(.title)
-                
+
                 TextField("Name", text: $name)
                 TextField("URL", text: $url)
-                
+
                 HStack {
                     Spacer()
-                    
+
                     Button("Cancel", role: .cancel) {
                         dismiss()
                     }
                     .focusable()
                     .keyboardShortcut(.escape)
-                    
+
                     Button("Save") {
                         deepLinks.edit(deepLink, name: name, url: url)
                         dismiss()


### PR DESCRIPTION
This addresses issue #196 by cleaning all the trailing whitespace and extra/missing newline warnings.