### PR TITLE
Remove redundant initializers

### DIFF
--- a/ControlRoom/Controllers/Snapshot.swift
+++ b/ControlRoom/Controllers/Snapshot.swift
@@ -15,10 +15,4 @@ struct Snapshot: Equatable, Hashable, Identifiable {
     static func == (lhs: Snapshot, rhs: Snapshot) -> Bool {
         lhs.id == rhs.id
     }
-    
-    init(id: String, creationDate: Date, size: Int) {
-        self.id = id
-        self.creationDate = creationDate
-        self.size = size
-    }
 }

--- a/ControlRoom/Helpers/URLFileAttribute.swift
+++ b/ControlRoom/Helpers/URLFileAttribute.swift
@@ -9,9 +9,9 @@
 import Foundation
 
 struct URLFileAttribute {
-    private(set) var folderSize: Int? = nil
-    private(set) var creationDate: Date? = nil
-    private(set) var modificationDate: Date? = nil
+    private(set) var folderSize: Int?
+    private(set) var creationDate: Date?
+    private(set) var modificationDate: Date?
 
     init(url: URL) {
         let path = url.path


### PR DESCRIPTION
While I was cleaning up SwiftLint warnings, I found these and fixed them in their own branch so the changes wouldn't collide with #197 

In summary, there's a member wise initializer for a struct that does not do anything different from what the synthesized initializer would do, and in a separate struct there are three optional variables that were being initialized to nil, which is what they would be automatically.