### PR TITLE
Fixed linter errors, warnings, and rule definition

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -2,11 +2,10 @@ type_name:
   allowed_symbols: "_"
 identifier_name:
   min_length: 2
+  allowed_symbols: "_"
 line_length:
   warning: 220
   error: 250
-identifier_name:
-  allowed_symbols: "_"
 
 disabled_rules:
   - non_optional_string_data_conversion

--- a/ControlRoom/Controllers/SimCtl+Types.swift
+++ b/ControlRoom/Controllers/SimCtl+Types.swift
@@ -19,7 +19,6 @@ extension SimCtl {
     enum DeviceFamily: CaseIterable {
         case iPhone
         case iPad
-        // swiftlint:disable:next identifier_name
         case tv
         case watch
         case visionPro

--- a/ControlRoom/Helpers/TypeIdentifier.swift
+++ b/ControlRoom/Helpers/TypeIdentifier.swift
@@ -17,7 +17,6 @@ struct TypeIdentifier: Hashable {
     static let watch = TypeIdentifier("com.apple.watch")
     static let vision = TypeIdentifier("com.apple.vision-pro")
 
-    // swiftlint:disable:next identifier_name
     static let tv = TypeIdentifier("com.apple.apple-tv")
 
     /// Default type identifiers to be used for unknown simulators

--- a/ControlRoom/Simulator UI/ControlScreens/SystemView/SystemView.swift
+++ b/ControlRoom/Simulator UI/ControlScreens/SystemView/SystemView.swift
@@ -218,7 +218,7 @@ struct SystemView: View {
 
 		let launchSpec = LSLaunchURLSpec(appURL: unmanagedTerminalUrl, itemURLs: unmanagedFolderUrl, passThruParams: nil, launchFlags: [], asyncRefCon: nil)
 
-		withUnsafePointer(to: launchSpec) { (pointer: UnsafePointer<LSLaunchURLSpec>) -> Void in
+		_ = withUnsafePointer(to: launchSpec) { (pointer: UnsafePointer<LSLaunchURLSpec>) in
 			LSOpenFromURLSpec(pointer, nil)
 		}
 	}


### PR DESCRIPTION
Swiftlint fixes to correct the build phase errors in #202:
* Consolidated duplicate swiftlint `identifier_name` entries so both `min_length` and `allowed_symbols` settings are applied.
* Removed unnecessary `swiftlint:disable` comments that are no longer needed. 
* Removed redundant void return type and explicitly discarded unused return value.

Resolves #202