### PR TITLE
Fix Swift 6 concurrency warnings and retroactive conformance (#199)

### DIFF
--- a/ControlRoom/Controllers/LocalSearchController.swift
+++ b/ControlRoom/Controllers/LocalSearchController.swift
@@ -115,16 +115,17 @@ class LocalSearchController: NSObject, ObservableObject {
 /// Adds `MKLocalSearchCompleterDelegate` conformance so the controller can use the delegate's callback methods
 extension LocalSearchController: MKLocalSearchCompleterDelegate {
     /// Called if `MKLocalSearchCompleter` return valid results from a query string
-    func completerDidUpdateResults(_ completer: MKLocalSearchCompleter) {
-        guard let callback else { return }
+    nonisolated func completerDidUpdateResults(_ completer: MKLocalSearchCompleter) {
         let results = completer.results.map {
-            LocalSearchResult( result: $0 )
+            LocalSearchResult(result: $0)
         }
-        callback(results)
+        Task { @MainActor [weak self] in
+            self?.callback?(results)
+        }
     }
 
     /// Called if `MKLocalSearchCompleter` encounters an error
-    func completer(_ completer: MKLocalSearchCompleter, didFailWithError error: Error) {
+    nonisolated func completer(_ completer: MKLocalSearchCompleter, didFailWithError error: Error) {
         print(error)
     }
 }

--- a/ControlRoom/Extensions/CLLocationCoordinate2D-Identifiable.swift
+++ b/ControlRoom/Extensions/CLLocationCoordinate2D-Identifiable.swift
@@ -9,8 +9,16 @@
 import CoreLocation
 import Foundation
 
+#if swift(>=5.10)
+extension CLLocationCoordinate2D: @retroactive Identifiable {
+    public var id: String {
+        "\(latitude)-\(longitude)"
+    }
+}
+#else
 extension CLLocationCoordinate2D: Identifiable {
     public var id: String {
         "\(latitude)-\(longitude)"
     }
 }
+#endif


### PR DESCRIPTION
## Summary

Fixes the remaining compiler warnings from #199 that weren't addressed by #200.

## Changes

### LocalSearchController.swift
- Marked `completerDidUpdateResults(_:)` and `completer(_:didFailWithError:)` as `nonisolated` to satisfy the nonisolated requirement of `MKLocalSearchCompleterDelegate`
- Wrapped the callback invocation in `Task { @MainActor in }` to safely access main-actor-isolated state
- This resolves the Swift 6 language mode error: *"Main actor-isolated instance method cannot be used to satisfy nonisolated requirement"*

### CLLocationCoordinate2D-Identifiable.swift
- Added `@retroactive` attribute to the `Identifiable` conformance on `CLLocationCoordinate2D`
- Used `#if swift(>=5.10)` conditional compilation for backward compatibility
- This resolves: *"Extension declares a conformance of imported type to imported protocol; this will not behave correctly if the owners of 'CoreLocation' introduce this conformance in the future"*

## Notes
- No behavioral changes — warning fixes only
- Builds successfully on Xcode 16.3 / macOS 15.3

## Checklist
- [x] SwiftLint returns no errors or warnings
- [x] Project builds successfully
- [x] Tested running the app with the simulator